### PR TITLE
Remove whoisdsmith prompt engineering gitbook link

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -84,7 +84,7 @@
 ## ▷ ChatGPT Prompts
 
 * ⭐ **[Awesome ChatGPT Prompts](https://prompts.chat/)** / [2](https://github.com/f/awesome-chatgpt-prompts) - Prompt Directory
-* ⭐ **[Prompt Engineering Guide](https://whoisdsmith.gitbook.io/pe-mthrfckr/)** or [Learn Prompting](https://learnprompting.org/) - Prompting Guides
+* ⭐ **[Prompt Engineering Guide](https://www.promptingguide.ai)** or [Learn Prompting](https://learnprompting.org/) - Prompting Guides
 * ⭐ **[quickref](https://quickref.me/chatgpt)** - Prompt Cheatsheet
 * ⭐ **[jailbreakchat](https://www.jailbreakchat.com/)** or [Chatbot Exploits](https://github.com/Cranot/chatbot-injections-exploits) - Jailbreak Prompts
 * [Chatgptjailbreak](https://rentry.org/Chatgptjailbreak) - Prompt Directory


### PR DESCRIPTION
### Changes:
- Remove whoisdsmith prompt engineering gitbook since it does not include code snippets.
- Replace it with original guide
