### PR TITLE
Add the Unsafe Site list to the main wiki

### DIFF
--- a/.github/add-headers.py
+++ b/.github/add-headers.py
@@ -20,7 +20,8 @@ headersData = {
     "TorrentPiracyGuide.md":    [":cyclone:",           "70", "# Torrenting", "Torrent Clients, Torrent Sites, Trackers"],
     "VideoPiracyGuide.md":      [":tv:",                "120", "# Movies / TV / Anime", "Stream Videos, Download Videos, Torrent Videos"],
     "base64.md":                [":key:",               "20", "", ""],
-    "img-tools.md":             [":camera:",            "55", "# Image Tools", ""]
+    "img-tools.md":             [":camera:",            "55", "# Image Tools", ""],
+    "UnsafeSites.md":           [":warning:",           "21", "# Unsafe Sites / Software list", ""]
 }
 
 def getHeaderForPage(pageFilename):

--- a/UnsafeSites.md
+++ b/UnsafeSites.md
@@ -1,0 +1,110 @@
+***
+***
+**[◄◄ Back to Wiki Index](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/index)**
+***
+***
+
+# ► Game Sites
+
+Note - Scene groups do not have their own sites, so its best to avoid anything claiming to represent one.
+
+- OceanOfGames - Caught with malware multiple times
+- CrackingPatching - Caught with [malware](https://redd.it/qy6z3c)
+- IGG / LoadGames - Added DRM to uploads, doxxed member
+- AGFY - Malicious redirect ads
+- AimHaven - Malicious redirect ads
+- SteamUnlocked - Malicious redirect ads, slow file host, IGG / nosteam uploads
+- GoGUnlocked / ROMsUnlocked - SteamUnlocked sister sites
+- xGIROx - Caught with malware
+- BBRepacks - Caught with malware
+- Seyter / Qoob - Caught with malware, tried to switch names from Seyter to Qoob, banned from rutracker for [weird installer behaviour](https://rutracker.org/forum/viewtopic.php?p=76324722#76324722)
+- cracked-games - Caught with malware
+- Wifi4Games - Caught with malware
+- GameFabrique - IGG uploads + [adware installers](https://rentry.co/GameFabrique_Adware/)
+- Fake FitGirl Sites- Official site is fitgirl-repacks.site, anything else is fake
+
+***
+***
+
+# ► Software / App Sites
+
+Note - YouTube videos claiming to give away free software are nearly always scams.
+
+- GetIntoPC / GetIntoMAC - Caught with malware multiple times
+- SadeemPC / SadeemAPK - Caught with malware multiple times
+- KaranPC - Caught with malware multiple times
+- AliTPB / AliPak / b4tman - Caught with malware multiple times
+- FTUApps - Caught with [malware](https://redd.it/120xk62)
+- S0ft4PC / Portable4PC - Caught with malware
+- CracksHash - Caught with [malware](https://redd.it/lklst7)
+- haxNode - Caught with malware
+- IGI30 - Caught with malware
+- MainRepo / MRepo - Caught with malware
+- AppValley / TutuBox / Ignition - History of [ddos attacks](https://github.com/nbats/FMHYedit/pull/307)
+- CNET / Download.com / ZDNET - History of [adware](https://www.reddit.com/r/software/comments/9s7wyb/whats_the_deal_with_sites_like_cnet_softonic_and/e8mtye9/)
+
+***
+***
+
+# ► Torrent Sites / Clients
+
+Note - Some aggregators search sites like TPB, so it's recommended to avoid using them for software and games.
+
+- Kickass Torrents - Official site is long gone, all that remain are sketchy copycats
+- The Pirate Bay / TPB - Site is no longer moderated, so its very risky for software and games
+- VSTorrent - Caught with [malware](https://redd.it/x66rz2)
+- uTorrent - Considered [adware](https://www.theverge.com/2015/3/6/8161251/utorrents-secret-bitcoin-miner-adware-malware), pre-adware versions exist, but its best to use [open source](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/torrent#wiki_.25BA_torrent_clients) clients
+- BitTorrent - Adware, owned by 'Rainberry, Inc.' (formerly BitTorrent, Inc.) who also own uTorrent
+- BitComet - Adware
+- Frostwire - [Adware](https://www.virustotal.com/gui/file/6a501792717fd86635d80fb258979b823fd53000c6d683904e2fb2407f1706fd)
+- BitLord - Adware
+- [Fake 1337x Sites](https://redd.it/117fq8t)
+
+***
+***
+
+# ► Software / Apps
+
+- Limewire - Dead for years, anything claiming to be them now should be avoided
+- Downloadly (video downloader) - [Crypto miner](https://www.youtube.com/watch?v=gjNZ2Y75Xhk) / Note that downloadly.ir is unrelated to this piece of software
+- Opera (browser) - [Poor privacy practices](https://www.kuketz-blog.de/opera-datensendeverhalten-desktop-version-browser-check-teil13/), [2](https://rentry.co/operagx) / [Predatory Loan Apps](https://www.androidpolice.com/2020/01/21/opera-predatory-loans/)
+- Chromium (browsers) - Manifest V3 will [handicap](https://www.eff.org/deeplinks/2021/12/chrome-users-beware-manifest-v3-deceitful-and-threatening) adblocking
+- McAfee - Preinstalled Bloatware
+- Avast - [Known for selling user data](https://www.vice.com/en/article/qjdkq7/avast-antivirus-sells-user-browsing-data-investigation)
+- AVG - Owned by Avast
+- CCleaner - Owned by Avast, best to use built in win 10/11 tool or bleachbit
+- Private Internet Access / ExpressVPN / ZenMate / CyberGhost - Owned by [Kape](https://restoreprivacy.com/kape-technologies-owns-expressvpn-cyberghost-pia-zenmate-vpn-review-sites/)
+- Acord (discord mod) - Has remote eval backdoor
+- BlueKik / Bluecord (chat mods) - History of [spam](https://www.reddit.com/r/NaviBot/comments/12h2v6n/the_truth_about_mods/) / [spying](https://rentry.co/tvrnw)
+- Kik (messanger) - App used by mostly [predators / scammers](https://youtu.be/9sPaJxRmIPc)
+- TLauncher (minecraft client) - [Shady business practices](https://redd.it/zmzzrt)
+- PolyMC (minecraft client) - Owner [kicked](https://redd.it/y6lt6s) all members from repo / discord
+- GShade (ReShade mod) - Dev added code that can trigger [unwanted reboots](https://rentry.co/GShade_notice)
+- OnStream - Closed source, [possibly malicious](https://rentry.co/upo2r)
+
+***
+***
+
+## ▷ Miscellaneous
+
+- [Fake Z-Lib Sites](https://i.imgur.com/z4Ku77B.png)
+
+***
+***
+
+## ▷ Adblock Filter List
+
+We have an Adblock Filter List for the sites included on the list. [Click here for the link to the filter list](https://gist.githubusercontent.com/Rust1667/df78d493cf3c00340c535d93e303c4f9/raw).
+
+***
+***
+
+## ▷ How-to Send Reports
+
+To suggest something for the list, please leave a comment on this [Reddit thread](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/comment/j4d2dld/), or contact us via [Divolt](https://redd.it/uto5vw).
+
+Never include a URL, just the name of the site / software, and the reason you feel people should avoid it.
+
+Note that our goal is to track things that should be avoided but still get recommended often, such as ThePirateBay.
+***
+***


### PR DESCRIPTION
This commit adds the unsafe site list to the wiki, then edits the headers so that it (should) appear in fmhy.pages.dev if this pull request is accepted!