### PR TITLE
UnsafeSites.md Clean-up 

### DIFF
--- a/UnsafeSites.md
+++ b/UnsafeSites.md
@@ -36,7 +36,7 @@
 * CracksHash - Caught with [malware](https://redd.it/lklst7)
 * haxNode - Caught with malware
 * IGI30 - Caught with malware
-* MainRepo / MrRepo - Caught with [malware](https://rentry.co/zu3i6)
+* MainRepo / MRepo - Caught with [malware](https://rentry.co/zu3i6)
 * AppValley / TutuBox / Ignition - History of [ddos attacks](https://github.com/nbats/FMHYedit/pull/307)
 * CNET / Download.com / ZDNET - History of [adware](https://www.reddit.com/r/software/comments/9s7wyb/whats_the_deal_with_sites_like_cnet_softonic_and/e8mtye9/)
 
@@ -61,13 +61,12 @@
 
 * Limewire - Dead for years, anything claiming to be them now should be avoided
 * Downloadly (video downloader) - Crypto miner / Note that downloadly.ir is [unrelated](https://i.imgur.com/1v46duO.png)
-* Opera (browser) - Poor [privacy practices](https://www.kuketz-blog.de/opera-datensendeverhalten-desktop-version-browser-check-teil13/), [2](https://rentry.co/operagx) / [Predatory Apps](https://www.androidpolice.com/2020/01/21/opera-predatory-loans/)
+* Opera (browser) - Poor [privacy practices](https://www.kuketz-blog.de/opera-datensendeverhalten-desktop-version-browser-check-teil13/), [2](https://rentry.co/operagx) / [Predatory Loan Apps](https://www.androidpolice.com/2020/01/21/opera-predatory-loans/)
 * Mcafee - Preinstalled Bloatware
 * Avast - Known for selling user data
 * AVG - Owned by Avast
 * CCleaner - Owned by Avast, best to use built in win 11 tool or bleachbit
-* Private Internet Access - Owned by [malware distributor Kape](https://redd.it/q3lepv)
-* ExpressVPN / ZenMate / CyberGhost - Owned by [Kape](https://rentry.co/i8dwr)
+* Private Internet Access / ExpressVPN / ZenMate / CyberGhost - Owned by [kape](https://restoreprivacy.com/kape-technologies-owns-expressvpn-cyberghost-pia-zenmate-vpn-review-sites/)
 * Acord (discord mod) - Has remote eval backdoor
 * BlueKik / Bluecord (chat mods) - History of [spam](https://redd.it/12h2v6n) / [spying](https://rentry.co/tvrnw)
 * Kik (messanger) - App used by mostly [predators / scammers](https://youtu.be/9sPaJxRmIPc)
@@ -90,7 +89,7 @@ Filter list for adblockers with sites from this thread.
 
 ### How-to Send Reports
 
-* To suggest something for the list, please leave a comment on this thread, or contact us via [Divolt](https://redd.it/uto5vw).
+* To suggest something for the list, please leave a comment on [this thread](https://www.reddit.com/r/FREEMEDIAHECKYEAH/comments/10bh0h9/unsafe_sites_software_thread/), or contact us via [Divolt](https://redd.it/uto5vw).
 
 * Never include a URL, just the name of the site / software, and the reason you feel people should avoid it. 
 


### PR DESCRIPTION
Some clean up of the unsafe sites entry;

- Fix MRepo typo (previously spelt as MrRepo)
- Add link to Reddit submission thread for users of fmhy.pages.dev
- merge duplicate (?) entry about kape - PIA was separated from Kapes other VPNs for some reason
- Specified that Opera had Predatory Loan Apps