### PR TITLE
Update GamingPiracyGuide.md

### DIFF
--- a/GamingPiracyGuide.md
+++ b/GamingPiracyGuide.md
@@ -185,7 +185,6 @@
 * [nwifiresticks](https://github.com/nbats/FMHYedit/blob/main/base64.md#nwifiresticks) - ROMs
 * [Rom Pack](https://www.ROMspack.com/) - ROMs
 * [Retrostic](https://www.retrostic.com/) - Emulators / ROMs
-* [ROMsUniverse](https://www.ROMsuniverse.com/) - Emulators / ROMs
 * [ROMsie](https://romzie.com/) - Emulators / ROMs
 * [Romsever](https://romsever.com) - Emulators / ROMs
 * [ROMs Games](https://www.ROMsgames.net/) - Emulators / ROMs
@@ -218,7 +217,6 @@
 * [DaROMs](http://daROMs.com/) - ROMs
 * [Arcade Punks](https://www.arcadepunks.com/) - ROMs
 * [NGR](https://www.nextgenroms.com/) - ROMs
-* [LoveROMs](https://www.loveROMs.online/) - ROMs
 * [FantasyAnime](https://fantasyanime.com/) - ROMs
 * [NesGM](https://nesgm.net/) - ROMs / [Translator](https://github.com/FilipePS/Traduzir-paginas-web)
 * [ROM World](http://www.romworldonline.com/) - ROMs / [How-to](https://i.ibb.co/vYJSs4d/dd99f3e3768d.png)


### PR DESCRIPTION
Possible future edits/removals:

* LegendaryRepacks - Discord link in the wiki is dead, I haven't found a new and updated link, it's the only way to access their stuff iirc. Whether or not there is a new link, I don't know.

Removed:

* ROMsUniverse - Downloads are dead (file not found)
* LoveROMs - Fake download buttons / riddled with pop up ads for non-adblock users - sometimes clicking the page in the wrong spot will pop up an ad. The real download button(s) are in small red text which is easy to miss. Site is likely unaffiliated with the original LoveROMs which closed a few years ago

Fake download link built into LoveROMs:

![image](https://github.com/fmhy/FMHYedit/assets/55948500/0acc75f5-5f04-44a9-b894-3075669da917)

Real download links for LoveROMs (Download, DiscX, etc):

![image](https://github.com/fmhy/FMHYedit/assets/55948500/5b9c15e7-8016-44e6-9472-998e9c44f566)
