### PR TITLE
Remove Sockshare link and some of it's clones

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -2441,10 +2441,7 @@ Add the following commands to a search to manually scrape each site.
 
 #### SockShare Clones
 
-* https://sockshare.fm/
-* https://sockshare.mn/
 * https://sockshare1.com/
-* https://www4.123movies.net/
 * https://www4.xmovies8.fm/
 * https://hdzer.com/
 * https://watchzer.com/
@@ -2456,13 +2453,10 @@ Add the following commands to a search to manually scrape each site.
 * https://putlocker.vc
 * https://123enjoy.net/
 * https://www2.putlockers.tw/
-* https://seriesonline.bz/
-* https://www2.putlockers.gy/
 * https://fmovies.onl/
 * https://www2.putlockers.ws/
 * https://movieload.net/
 * https://5movies.fm/
-* https://www1.ezlive.tv/
 * https://www1.f123movies.com/
 * https://vo32.com/
 

--- a/VideoPiracyGuide.md
+++ b/VideoPiracyGuide.md
@@ -82,7 +82,7 @@
 * ⭐ **[FshareTV](https://fsharetv.co/)** - Movies / 1080p
 * ⭐ **[RidoMovies](https://ridomovies.pw/)** - Movies / 1080p
 * ⭐ **[Ling.online](https://ling-online.net/en/videos/films/)** - Movies / TV / 1080p
-* ⭐ **[SockShare](http://sockshare.ac/)** - Movies / TV / Anime / 1080p / [Mirrors](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_sockshare_clones) / Use Adblock
+* [SockShare Mirrors](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_sockshare_clones) - Movies / TV / Anime / 1080p / Use Adblock
 * [LookMovie](https://lookmovie2.to/) - Movies / TV / 720p / [Mirrors](https://proxymirrorlookmovie.github.io/)
 * [Tubi](https://tubitv.com) - Movies / TV / 720p / Use Adblock / [Downloader](https://github.com/warren-bank/node-hls-downloader-tubitv)
 * [YesMovies](https://yesmovies.ag/), [2](https://www2.solarmovie.to/), [3](https://ww5.0123movie.net/), [4](https://ww1.putlocker.vip/) - Movies / TV / Anime / 1080p


### PR DESCRIPTION
Sockshare's official domains have expired, same goes for some of the clones.

These commits remove the star status of sockshare and replaces the sockshare entry with the list of mirrors, I checked xmovies8 and content still plays so I think the clones are fine. It also removes the dead clones which no longer work, either exipired domains or dead servers as is the case with www4[.]123movies[.]net