### PR TITLE
Added Smutbase to NSFW

### DIFF
--- a/NSFWPiracy.md
+++ b/NSFWPiracy.md
@@ -379,6 +379,7 @@ Note - This list only contains sites / tools not found on [PornDude](https://the
 * [electric.smut](https://nsfwai.com/) or [PornPen](https://pornpen.ai/) - NSFW Image Generators
 * [MoanMyIP](https://www.moanmyip.com/) - Sexy Girls Moaning Your IP
 * [AdultOpenAI](http://adultopenai.pythonanywhere.com/) or [Unhinged](https://www.unhinged.ai/) - NSFW Ai Chatbots
+* [SmutBase](https://smutba.se/) - NSFW Model Download
 
 ***
 

--- a/single-page
+++ b/single-page
@@ -22092,6 +22092,7 @@ Note - This list only contains sites / tools not found on [PornDude](https://the
 * [electric.smut](https://nsfwai.com/) or [PornPen](https://pornpen.ai/) - NSFW Image Generators
 * [MoanMyIP](https://www.moanmyip.com/) - Sexy Girls Moaning Your IP
 * [AdultOpenAI](http://adultopenai.pythonanywhere.com/) or [Unhinged](https://www.unhinged.ai/) - NSFW Ai Chatbots
+* [SmutBase](https://smutba.se/) - NSFW Model Download
 
 ***
 


### PR DESCRIPTION
Smutbase is a sister website to Open3DLab & SFMLab (both of which are already on the Wiki) with the main difference on this sister site being primary NSFW Models