### PR TITLE
Update STORAGE.md

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -2966,11 +2966,16 @@ Add the following commands to a search to manually scrape each site.
 
 ***
 
-#### Typing Lessons
+#### Typing Lessons / Tests
 
-* ⭐ **[Monkey Type](https://monkeytype.com/)**
+* ⭐ **[Monkey Type](https://monkeytype.com/)** - Customizable Typing Tests
+* [Colemak Academy](https://www.colemak.academy/) - Alternative / Custom Keyboard Based Typing Tests
+* [Ttyper](https://github.com/max-niederman/ttyper), [TermTyper](https://github.com/kraanzu/termtyper) - Terminal Typing Tests
+* [TypeLit.io](https://www.typelit.io/) - Practice Typing by Retyping Books
+* [10fastfingers](https://10fastfingers.com/) - Typing Competitions
+* [klavaro](https://klavaro.sourceforge.io/), [TypingStudy](https://www.typingstudy.com/), [TypeFast](https://typefast.io/) - Multilingual Typing Lessons / Tests
 
-**Lessons** - [keybr](https://www.keybr.com/), [Typing.com](https://www.typing.com/), [Colemak Academy](https://www.colemak.academy/), [RapidTyping](https://rapidtyping.com/), [Typing Club](https://www.typingclub.com/), [TypeFast](https://typefast.io/), [typing.academy](https://www.typing.academy/), [klavaro](https://sourceforge.net/projects/klavaro/), [10fastfingers](https://10fastfingers.com/), [Ttyper](https://github.com/max-niederman/ttyper), [TermTyper](https://github.com/kraanzu/termtyper), [kbs](https://kbs.im/), [TypingStudy](https://www.typingstudy.com/), [TypeLit.io](https://www.typelit.io/)
+**Lessons** - [keybr](https://www.keybr.com/), [Typing.com](https://www.typing.com/), [Typing Club](https://www.typingclub.com/), [typing.academy](https://www.typing.academy/)
 
 **Games** - [TypeRacer](https://play.typeracer.com/), [ZType](https://zty.pe/), [TypeRush](https://www.typerush.com/)
 


### PR DESCRIPTION
First things first, added descriptions for a bunch of unique stuff. It's much better to actually leave descriptions whenever possible so if people are looking for, let's say, a terminal typing test, they can find it simply by searching and won't have to go through 10 links before they get to it.

Simply putting almost every link next to lessons is messy at best and misleading at worst since some of those links aren't typing lessons, they're exclusively typing tests or ways to practice typing.

Also, there were 2 instances of klavaro, the site link and the sourceforge link. You can get to the sourceforge download link from the site and it's much easier to navigate the site since it has translations for a bunch of languages, so I left the site link. I also divided klavaro, typefast, and typingstudy from regular typing lessons because those are the only ones that have multilingual options, and I think they're worth separating for the sake of people having an easier time finding a non-english exclusive typing lessons/tests.

Typelit.io is very unique in the sense that it's the only site where you can practice typing by retyping books. It doesn't really fit under lessons since there's no lessons, it's just an interesting way to practice.

Colemak is unique because while it is a pretty bare-bones typing test, it does offer alternative keyboard options (colemak, dvorak, tarmak, workman etc.) as well as a custom keyboard layout, so I think it's worth mentioning that in the description so folks who use non QWERTY based keyboards can have an easier time finding the typing test they need. It also really doesn't fit next to lessons since, again, it has no lessons.

Generally even just leaving monkeytype without a description implies it's a site for typing lessons, which it is not. It's a site for customizable typing tests, which can assist in improving typing skill, but it isn't an actual lesson or a tutorial by any means.

10fastfingers is pretty much the only site with active typing competitions, so it's worth separating from regular lesson sites. Again, makes it way easier for users to find what they need and saves them the time of clicking through shitton of links for a niche they need.

Now onto the removed stuff:

* [Typing Finger Positions](https://i.ibb.co/L8VY6xR/Finger-position-on-a-keyboard.png) - it's just an image. The exact same image you'd find on pretty much any typing lesson or even typing test site, except those also come with the additional features of actually being useful since you're doing something and they generally show you what keys you're pressing as well. I really doubt anybody would spare more than a few seconds looking at this image, let alone just have it left in a tab and looking back on it whenever they try to type to remind themselves of the finger positioning. For people who wanna learn typing, there's plenty of actually interactive lessons which beat just staring at an image. And even if someone needs this, it's one search away. It's on just about every typing related site. Just save this for the FreeImagesHeckYeah wiki.

* [Dance Mat Typing](https://www.bbc.co.uk/bitesize/topics/zf2f9j6/articles/z3c6tfr) - Nobody above the age of 8 has any real use for this. There's plenty of other lessons you can more easily navigate and that don't come with an obnoxious animation and music.

* [RapidTyping](https://rapidtyping.com/) - it was last updated 2 years ago, most likely a dead project, has nothing the other sites/apps don't already offer and is pretty bloat since it's 50MB. There's really no good explanation for why software this simplistic would be 50MB unless it's just badly coded or has a bunch of useless shit. The UI itself is not really pleasant either.

* [kbs](https://kbs.im/) - bare-bones typing test. The only kind of special thing about it is you can change keyboard colors. That's about it. But even that is pretty much useless since you're not going to be looking at the image of a keyboard during the typing test, you're going to be looking at the words which are above it. The project was also last updated almost 2 years ago, so it's really unlikely it'll have any new features.

Last thing, I've renamed Typing Lessons to Typing Lessons / Tests since there's really both of those in this category and some sites don't have lessons at all, so I thought the category name just being Typing Lessons was kind of misleading. Typing games also generally fit more into the typing tests niche.