### PR TITLE
Update STORAGE.md

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1,3 +1,4 @@
+
 ***
 ***
 **[◄◄ Back to Wiki Index](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/index)**
@@ -497,7 +498,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://185.215.227.81:
 
 #### Custom Rich Discord Presence
 
-[CustomRP](https://www.customrp.xyz/), [CustomDiscordRPC](https://github.com/hohltier/CustomDiscordRPC), [DiscordRPCMaker](https://drpcm.t1c.dev/)
+* ⭐ **[CustomRP](https://www.customrp.xyz/)**
 
 ***
 
@@ -557,19 +558,18 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://185.215.227.81:
 
 #### Discord Embed Generators
 
-* ⭐ **[Rauf's Embed Generator](https://embed.rauf.wtf)**
+* ⭐ **[Discohook](https://discohook.org/)** - [Discohook Utils](https://dutils.shay.cat/)
 
-[PSDiscord](https://github.com/EvotecIT/PSDiscord), [Discohook](https://discohook.org/), [Embed Generator](https://message.style/), [0x71 Discord Embed API](https://em.0x71.cc/), [TitanEmbeds](https://titanembeds.com/)
-
+[PSDiscord](https://github.com/EvotecIT/PSDiscord), [Embed Generator](https://message.style/)
 ***
 
 #### Discord Server / Bot Lists
 
-[DISBOARD](https://disboard.org/), [Discord Labs](https://www.discordlabs.org/), [Discord Servers](https://discordservers.com/), [Discadia](https://discadia.com/), [DiscordList](https://discordlist.me/), [Discords.com](https://discords.com/), [Discord Me](https://discord.me/), [Disforge](https://disforge.com/), [Find a Discord](https://findadiscord.com/), [Open Source Projects](https://discord.com/open-source)
+[DISBOARD](https://disboard.org/), [Discord Servers](https://discordservers.com/), [Discadia](https://discadia.com/), [Discords.com](https://discords.com/), [Discord Me](https://discord.me/), [Disforge](https://disforge.com/), [Find a Discord](https://findadiscord.com/), [Open Source Projects](https://discord.com/open-source)
 
 **Bots**
 
-[BotBlock](https://botblock.org/), [Top.gg](https://top.gg/), [Bots on Discord](https://bots.ondiscord.xyz/), [Discord Bots](https://discord.bots.gg/), [Top Bots](https://gist.github.com/advaith1/451dcbca2d7c3503d4f48d63eb918cb0), [Motion Botlist](https://motiondevelopment.top/bot), [Infinity Bot List](https://infinitybots.gg/), [Discord Services](https://discordservices.net/), [DiscordBots](https://discordbots.co/), [Discord Bot List](https://discordbotlist.com/), [Carbon Bot List](https://www.carbonitex.net/discord/bots), [Botlist.me](https://botlist.me/), [TopCord](https://topcord.xyz/), [YABL](https://yabl.xyz/), [Wonder Bot List](https://wonderbotlist.com/), [Void Bots](https://voidbots.net/), [Discord Botlist](https://discord-botlist.eu/)
+[BotBlock](https://botblock.org/), [Top.gg](https://top.gg/), [Bots on Discord](https://bots.ondiscord.xyz/), [Discord Bots](https://discord.bots.gg/), [Top Bots](https://gist.github.com/advaith1/451dcbca2d7c3503d4f48d63eb918cb0), [Motion Botlist](https://motiondevelopment.top/bot), [Infinity Bot List](https://infinitybots.gg/), [Discord Services](https://discordservices.net/), [DiscordBots](https://discordbots.co/), [Discord Bot List](https://discordbotlist.com/), [Carbon Bot List](https://www.carbonitex.net/discord/bots), [Botlist.me](https://botlist.me/), [TopCord](https://topcord.xyz/), [Void Bots](https://voidbots.net/), [Discord Botlist](https://discord-botlist.eu/)
 
 ***
 


### PR DESCRIPTION
**Changes made in Discord Embed Generators:**

- Removed [Rauf's Embed Generator](https://embed.rauf.wtf) because it got shut down

- Removed [TitanEmbeds](https://titanembeds.com/) since it's no longer maintained https://prnt.sc/NMaCNw3H-Y4h

- Removed [0x71 Discord Embed API](https://em.0x71.cc/) because it has very little customizability options and openly admits to collecting IPs


- Starred [Discohook](https://discohook.org/), it's very easy to use, lots of embed customization options, exporting/importing as well as saving backups of embeds is available. Also added the link to discohook utils which help enhance the discohook experience, particularly the discohook utils bot which can restore a discohook embed edit/view link, so even if you forgot to make a backup you can still recover and edit the embed with the bot


**Changes made in Discord Server / Bot Lists:**

- Removed [Discord Labs](https://www.discordlabs.org/), seems broken since both discord bot labs and statcord link give 502 error

- Removed [DiscordList](https://discordlist.me/), appears to be dead

- Removed [Wonder Bot List](https://wonderbotlist.com/) since it's in French and mostly promotes french bots, it should be moved to the non-eng French section

- Removed [YABL](https://yabl.xyz/), very small amount of bots showcased and hasn't been updated in almost a year

**Changes made in Custom Rich Discord Presence (Which should be renamed to Discord Custom Rich Presence):**

- Removed [CustomDiscordRPC](https://github.com/hohltier/CustomDiscordRPC) since last update was 2 years ago and it doesn't have any features [CustomRP](https://www.customrp.xyz/) doesn't already have

- Removed [DiscordRPCMaker](https://drpcm.t1c.dev/) since it's been archived and will not be updated anymore

- Starred [CustomRP](https://www.customrp.xyz/), it's regularly updated, multilingual and very lightweight. Also has plenty of features and pretty much everything you could ask for in a custom RP