### PR TITLE
Update TOOLSGuide.md

### DIFF
--- a/TOOLSGuide.md
+++ b/TOOLSGuide.md
@@ -649,14 +649,11 @@
 * ⭐ **[Development Learning](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/dev-tools#wiki_.25BA_learning_.2F_cheat_sheets)** - Developer Learning Tools
 * ⭐ **[Website Development](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/dev-tools#wiki_.25B7_web_development)** - Site Development Tools
 * [KickResume](https://www.kickresume.com/en/help-center/resume-samples/) or [ThisResumeDoesNotExist](https://thisresumedoesnotexist.com/) - Resume Samples
-* [GitHub Résumé](https://github.com/resume/resume.github.com) - Generate Resume from GitHub Activity
-* [AskEdith](https://www.askedith.ai/demo) - Ask AI Job / Business Questions
 * [LoopCV](https://www.loopcv.pro/) - Automated Job Search Tool
 * [Toby Tools](https://rentry.co/qnu6x) or [EuroJobs](https://eurojobs.com/) - Job Search Tools
 * [50WaysToGetAJob](https://50waystogetajob.com/) - Interactive Job Search Guide
-* [10xJobs](https://10xjobs.net/) - Tech Job Search
+* [10xJobs](https://10xjobs.net/) - Find High Paying Tech Jobs
 * [Arvrok](https://www.arvrok.com/) - Immersive Tech Job Search
-* [EconJobRumors](https://www.econjobrumors.com/) - Economic Job Market Forum
 * [SocJobRumors](https://www.socjobrumors.com/) - Sociology Job Market Forum
 * [80,000 Hours](https://80000hours.org/) - Explore Career Options
 * [Comparably](https://www.comparably.com/) or [GoodFirms](https://www.goodfirms.co/) - Compare Companies / Salaries


### PR DESCRIPTION
**Changes made in Career Tools:**

- Removed [AskEdith](https://www.askedith.ai/demo), free tier is limited to 30 questions/mo, 1 project and dashboard. doesn't really seem worth keeping since it's only useful for big companies to analyze their data

- Removed [GitHub Résumé](https://github.com/resume/resume.github.com), last updated 2016 and seems to no longer be maintained. overall it's not really that useful in the first place since you have to star it to use it with your GH profile and the information it shows can be easily found on your profile in the first place

- Changed the description of [10xJobs](https://10xjobs.net/) to "Find High Paying Tech Jobs" since "Tech Job Search" didn't really fit it. It doesn't offer the ability to search at all, but it does list lots of very high end tech jobs from various locations that are currently hiring

- Removed [EconJobRumors](https://www.econjobrumors.com/), it doesn't appear to be moderated and most posts have nothing to do with economics or economy related jobs. it's pretty much free-range discussion forum, with mostly stuff related to politics and current events: https://prnt.sc/JIVmBUCVUe3k