### PR TITLE
Update STORAGE.md

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -583,20 +583,35 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://185.215.227.81:
 
 ***
 
-## Decentralized Social Networks
+## Fediverse 
 
-* ⭐ **[Mastodon](https://joinmastodon.org/)**
-* ⭐ **[Pleroma](https://pleroma.social/)**
-* ⭐ **[diaspora*](https://diasporafoundation.org/)**, [2](https://diasp.org/)
-* ⭐ **[Fediverse](https://fediverse.party/)**, [Fediverse.space](https://fediverse.space/), [sub.rehab](https://sub.rehab/)  or [Fediverse Observer](https://mastodon.fediverse.observer/) - Fediverse Community / Instance Search
+* ⭐ **[Fediverse](https://fediverse.party/)**, [Fediverse.space](https://fediverse.space/) or [Fediverse Observer](https://fediverse.observer/) - Fediverse Community / Instance Search
 * ⭐ **[Fedi Tips](https://fedi.tips/)** - Mastodon / Fediverse Guide
+* ⭐ **[Fediverse Stats](https://the-federation.info/) or [FediDB](https://fedidb.org/)** - Fediverse statistics
 * ⭐ **[Awesome Fediverse](https://github.com/emilebosch/awesome-fediverse)** - Fediverse Resources
-
-[Misskey](https://join.misskey.page/en/), [Twetch](https://twetch.app/welcome), [Manyverse](https://www.manyver.se/), [Friendica](https://friendi.ca/), [Hubzilla](https://zotlabs.org/page/hubzilla/hubzilla-project), [Movim](https://movim.eu/), [Pixelfed](https://pixelfed.org/), [GoToSocial](https://docs.gotosocial.org/en/latest/), [LIBRANET.de](https://libranet.de/)
+* ⭐ **[Mastodon](https://joinmastodon.org/)** - Federated microblogging / X(Twitter) Alternative / [Mastodon Tools](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage/#wiki_mastodon_tools)
+* ⭐ **[Pixelfed](https://pixelfed.org/)** - Federated image sharing platform / Instagram Alternative
+* ⭐ **[Pleroma](https://pleroma.social/)** - Federated Microblogging 
+* [Friendica](https://friendi.ca/) - Federated Macroblogging / Facebook Alternative
+* [diaspora*](https://diasporafoundation.org/), [2](https://diasp.org/) - Federated Macroblogging / Google+ Alternative 
+* [Hubzilla](https://zotlabs.org/page/hubzilla/hubzilla-project) - Federated feature-rich Macroblogging
+* [Misskey](https://join.misskey.page/en/) or [Firefish](https://joinfirefish.org/) - Federated feature-rich Microblogging
+* [GoToSocial](https://docs.gotosocial.org/en/latest/) - Safety & Privacy-focused Federated Microblogging
+* [Lemmy](https://join-lemmy.org/) - Link Aggregator/ Federated Reddit Alternative / [Lemmy Tools](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage/#wiki_lemmy_tools)
+* [Kbin](https://kbin.pub/) - Federated Link Aggregator & Microblogging
+* [Funkwhale](https://funkwhale.audio/) - Decentralized audio sharing 
+* [Bookwyrm](https://joinbookwyrm.com/) - Federated Social reading & Book tracking / Goodreads Alternative 
+* [Peertube](https://joinpeertube.org/en), [2](https://search.joinpeertube.org/) / [Instances](https://instances.joinpeertube.org/instances) - Decentralized video hosting
+* [Castopod](https://castopod.org/) - Federated podcast hosting 
 
 ### Mastodon Tools
 
 [Web Client](https://pinafore.social/) / [Desktop Client](https://tuba.geopjr.dev/), [2](https://kaiteki.app/) / [Schedule](https://scheduler.mastodon.tools/) / [Twitter Sync](https://github.com/klausi/mastodon-twitter-sync) / [Instances](https://instances.social/) / [Twitter Account Link](https://moaparty.com/) / [Embedded Feeds](https://www.mastofeed.com/) / [Timelines](https://mastovue.glitch.me/) / [Create Bots](https://cheapbotstootsweet.com/)
+
+### Lemmy Tools 
+
+* [sub.rehab](https://sub.rehab/) - Find subreddits on Lemmy
+* [Lemmy Explorer](https://lemmyverse.net/)**, [Community-Browser](https://browse.feddit.de/) or [Awesome Instances](https://github.com/maltfield/awesome-lemmy-instances) - Lemmy Instances
 
 ***
 


### PR DESCRIPTION
- Renamed Decentralized Social Networks to Fediverse 
- Removed Libranet(its a friendica instance), manyver(not fediverse compatible or really popular decentralized network afaik) & twetch(similar reason to manyver )
- added a reddit link for lemmy tools section, url should be valid once reddit updates

I'll make pull requests on the other pages for where https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_decentralized_social_networks appears and replace with https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_fediverse ~ so we dont have broken urls in the wiki