### PR TITLE
Update Non-English.md

### DIFF
--- a/Non-English.md
+++ b/Non-English.md
@@ -1666,6 +1666,7 @@
 ## ▷ Reading
 
 * ⭐ **[Spanish Reading CSE](https://cse.google.com/cse?cx=85e4a562f2abf40f6)** / [SMAGX](https://smagx.com/) - Multi-Site Book Search
+* [Lectulandia](https://ww3.lectulandia.com/), [2](https://ww3.lectulandia.co/) - Books
 * [MundoEpubGratis](https://mundoepubgratis2.com/) - Books
 * [libronube](https://www.libronube.com/) - Books
 * [eBiblioteca](https://ebiblioteca.org/) - Books
@@ -1674,7 +1675,6 @@
 * [LectuEpubGratis](https://lectuepubgratis2.com/) - Books
 * [Ebookelo](https://ww2.ebookelo.com/) - Books
 * [EspaEbook](https://www.espaebook2.com/) - Books
-* [Lectulandia](https://ww3.lectulandia.com/), [2](https://ww3.lectulandia.co/) - Books
 * [La Pirateca](https://lapirateca.com/) - Books
 * [DebeLeer](https://www.debeleer.com/) - Books
 * [Elejandría](https://www.elejandria.com/) - Books

--- a/Non-English.md
+++ b/Non-English.md
@@ -1670,12 +1670,12 @@
 * [libronube](https://www.libronube.com/) - Books
 * [eBiblioteca](https://ebiblioteca.org/) - Books
 * [ePub Gratis](https://www.epubgratis.info/) - Books
-* [Lectuepub](https://lectuepub2.com/) - Books
+* [LectuEpub](https://lectuepub2.com/) - Books
+* [LectuEpubGratis](https://lectuepubgratis2.com/) - Books
 * [Ebookelo](https://ww2.ebookelo.com/) - Books
-* [La Pirateca](https://lapirateca.com/) - Books
 * [EspaEbook](https://www.espaebook2.com/) - Books
 * [Lectulandia](https://ww3.lectulandia.com/), [2](https://ww3.lectulandia.co/) - Books
-* [LectuEpubGratis](https://lectuepubgratis2.com/) - Books
+* [La Pirateca](https://lapirateca.com/) - Books
 * [DebeLeer](https://www.debeleer.com/) - Books
 * [Elejandría](https://www.elejandria.com/) - Books
 * [El Libro Total](https://www.ellibrototal.com/ltotal/) - Books / Audiobooks

--- a/Non-English.md
+++ b/Non-English.md
@@ -1666,13 +1666,13 @@
 ## ▷ Reading
 
 * ⭐ **[Spanish Reading CSE](https://cse.google.com/cse?cx=85e4a562f2abf40f6)** / [SMAGX](https://smagx.com/) - Multi-Site Book Search
-* [Lectulandia](https://ww3.lectulandia.com/), [2](https://ww3.lectulandia.co/) - Books
 * [MundoEpubGratis](https://mundoepubgratis2.com/) - Books
 * [libronube](https://www.libronube.com/) - Books
 * [eBiblioteca](https://ebiblioteca.org/) - Books
 * [ePub Gratis](https://www.epubgratis.info/) - Books
 * [LectuEpub](https://lectuepub2.com/) - Books
 * [LectuEpubGratis](https://lectuepubgratis2.com/) - Books
+* [Lectulandia](https://ww3.lectulandia.com/), [2](https://ww3.lectulandia.co/) - Books
 * [Ebookelo](https://ww2.ebookelo.com/) - Books
 * [EspaEbook](https://www.espaebook2.com/) - Books
 * [La Pirateca](https://lapirateca.com/) - Books

--- a/Non-English.md
+++ b/Non-English.md
@@ -1669,6 +1669,7 @@
 * [eBiblioteca](https://ebiblioteca.org/) - Books
 * [Ebookelo](https://ww2.ebookelo.com/) - Books
 * [La Pirateca](https://lapirateca.com/) - Books
+* [EspaEbook](https://www.espaebook2.com/) - Books
 * [Lectulandia](https://ww3.lectulandia.com/), [2](https://ww3.lectulandia.co/) - Books
 * [ePub Gratis](https://www.epubgratis.info/) - Books
 * [Todolibros](https://todolibros.net/) - Books

--- a/Non-English.md
+++ b/Non-English.md
@@ -1673,6 +1673,7 @@
 * [ePub Gratis](https://www.epubgratis.info/) - Books
 * [Todolibros](https://todolibros.net/) - Books
 * [Lectuepub](https://lectuepub2.com/) - Books
+* [LectuEpubGratis](https://lectuepubgratis2.com/) - Books
 * [MundoEpubGratis](https://mundoepubgratis2.com/) - Books
 * [libronube](https://www.libronube.com/) - Books
 * [DebeLeer](https://www.debeleer.com/) - Books

--- a/Non-English.md
+++ b/Non-English.md
@@ -1576,7 +1576,7 @@
 * [PasateaTorrent](https://pasateatorrent.org/) - Movies / TV / Castilian
 * [Cinecalidad](https://cinecalidad.one/) - Movies / TV / Latino
 * [Tlandia](https://torrentlandia.site/) - Movies / Latino
-* [DiXvA](https://www.dixva.com/) - Movies / TV / Music / NSFW / [Telegram](https://t.me/+YSdB1y9VdjAzNDkx)
+* [DiXvA](https://www.dixva.com/), [2](https://www.sinsitio.site/) - Movies / TV / Music / NSFW / [Telegram](https://t.me/+YSdB1y9VdjAzNDkx)
 * [Zonatorrent](https://zonatorrent.in/) - Movies / TV / Castilian / [Bypasser script](https://greasyfork.org/en/scripts/462510-spanish-torrent-sites-short-link-bypasser)
 * [Frozen-Layer](https://www.frozen-layer.com/) - Anime
 * [unionfansub](https://foro.unionfansub.com/index.php) - Anime

--- a/Non-English.md
+++ b/Non-English.md
@@ -1675,9 +1675,10 @@
 * [Lectulandia](https://ww3.lectulandia.com/), [2](https://ww3.lectulandia.co/) - Books
 * [Ebookelo](https://ww2.ebookelo.com/) - Books
 * [EspaEbook](https://www.espaebook2.com/) - Books
-* [La Pirateca](https://lapirateca.com/) - Books
 * [DebeLeer](https://www.debeleer.com/) - Books
 * [Elejandría](https://www.elejandria.com/) - Books
+* [La Pirateca](https://lapirateca.com/) - Books
+* [Books and Bots](http://bibliotecasecreta.nl/) - Books / Telegram
 * [El Libro Total](https://www.ellibrototal.com/ltotal/) - Books / Audiobooks
 * [BladeMaster666](https://blademaster666.com/) - Newspapers / Magazines / Spain / NSFW
 * [FreeLibros](https://www.freelibros.net/) - Textbooks / Books / Audiobooks / Magazines / Courses / Documentaries

--- a/Non-English.md
+++ b/Non-English.md
@@ -1669,12 +1669,12 @@
 * [MundoEpubGratis](https://mundoepubgratis2.com/) - Books
 * [libronube](https://www.libronube.com/) - Books
 * [eBiblioteca](https://ebiblioteca.org/) - Books
+* [ePub Gratis](https://www.epubgratis.info/) - Books
 * [Lectuepub](https://lectuepub2.com/) - Books
 * [Ebookelo](https://ww2.ebookelo.com/) - Books
 * [La Pirateca](https://lapirateca.com/) - Books
 * [EspaEbook](https://www.espaebook2.com/) - Books
 * [Lectulandia](https://ww3.lectulandia.com/), [2](https://ww3.lectulandia.co/) - Books
-* [ePub Gratis](https://www.epubgratis.info/) - Books
 * [LectuEpubGratis](https://lectuepubgratis2.com/) - Books
 * [DebeLeer](https://www.debeleer.com/) - Books
 * [Elejandría](https://www.elejandria.com/) - Books

--- a/Non-English.md
+++ b/Non-English.md
@@ -1582,6 +1582,7 @@
 * [unionfansub](https://foro.unionfansub.com/index.php) - Anime
 * [Akiba-kei](http://akiba-team.org/) - Anime
 * [Animextremist](http://animextremist.com/) - Anime / Manga
+* [epublibre](https://www.epublibre.org/) - Books
 * [El Plan](https://hackmd.io/@w8tAmGnzT-qbgHkemaly6A/SEGUNDA-PARTE), [2](https://www.reddit.com/user/No_Land656) - Live Sports Acestream IDs
 * [elcano](https://sg.hideip.co/direct/aHR0cDovL2VsY2Fuby50b3Av), [2](https://sg.4everproxy.com/direct/aHR0cDovL2VsY2Fuby50b3Av) - Live Sports Acestream IDs / [Matrix](https://matrix.to/#/!zrcckivBbqZjmykTPi:sibnsk.net?via=matrix.org&via=sibnsk.net) / [Link Scraper](https://github.com/ddgarciad03/IDS-Export)
 
@@ -1665,18 +1666,16 @@
 ## ▷ Reading
 
 * ⭐ **[Spanish Reading CSE](https://cse.google.com/cse?cx=85e4a562f2abf40f6)** / [SMAGX](https://smagx.com/) - Multi-Site Book Search
-* [epublibre](https://www.epublibre.org/) - Books
+* [MundoEpubGratis](https://mundoepubgratis2.com/) - Books
+* [libronube](https://www.libronube.com/) - Books
 * [eBiblioteca](https://ebiblioteca.org/) - Books
+* [Lectuepub](https://lectuepub2.com/) - Books
 * [Ebookelo](https://ww2.ebookelo.com/) - Books
 * [La Pirateca](https://lapirateca.com/) - Books
 * [EspaEbook](https://www.espaebook2.com/) - Books
 * [Lectulandia](https://ww3.lectulandia.com/), [2](https://ww3.lectulandia.co/) - Books
 * [ePub Gratis](https://www.epubgratis.info/) - Books
-* [Todolibros](https://todolibros.net/) - Books
-* [Lectuepub](https://lectuepub2.com/) - Books
 * [LectuEpubGratis](https://lectuepubgratis2.com/) - Books
-* [MundoEpubGratis](https://mundoepubgratis2.com/) - Books
-* [libronube](https://www.libronube.com/) - Books
 * [DebeLeer](https://www.debeleer.com/) - Books
 * [Elejandría](https://www.elejandria.com/) - Books
 * [El Libro Total](https://www.ellibrototal.com/ltotal/) - Books / Audiobooks


### PR DESCRIPTION
spanish sites
- removed todolibros.netbecause of unbypasseable shorteners
- bumped up better book sites (with more contents and no fake download buttons close to the good ones)
- moved epublibre.org to torrents
- added extra domain sinsitio.site
- added back lectuepubgratis2.com that seemed dead
- added espaebook2.com
- added bibliotecasecreta.nl