### PR TITLE
Update STORAGE.md

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1263,7 +1263,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 * ⭐ **[fast](https://fast.com/)** / [CLI](https://github.com/sindresorhus/fast-cli)
 * ⭐ **[Cloudflare Speed Test](https://speed.cloudflare.com/)**
 
-[LibreSpeed](https://librespeed.org/), [Xfinity Speed Test](https://speedtest.xfinity.com/), [DLS Reports](http://www.dslreports.com/tools), [Bandwidth Place](https://www.bandwidthplace.com/), [Speedtest](https://www.speedtest.net/), [wifiman](http://wifiman.com/), [Net Speed Meter](https://www.microsoft.com/en-gb/p/app/9nmbx01pxz4l), [PeerFast](https://diegorbaquero.github.io/PeerFast/) (P2P), [Speedtest-Tracker](https://github.com/henrywhitaker3/Speedtest-Tracker), [GoogleFiber](http://speedtest.googlefiber.net/), [speedtestcustom](https://pcmag.speedtestcustom.com/), [SpeedOf.Me](https://speedof.me/), [BroadbandSpeedChecker](https://broadbandspeedchecker.co.uk/), [speed.io](https://speed.io/), [att](https://www.att.com/support/speedtest/), [speedcheck](https://www.speedcheck.org/), [testmyspeed](https://testmyspeed.onl/), [testmy](https://testmy.net/), [Meter](https://www.meter.net/), [CIRA](https://performance.cira.ca/), [Speedsmart](https://speedsmart.net/), [OpenSpeedTest](https://openspeedtest.com/)
+[LibreSpeed](https://librespeed.org/), [Bandwidth Place](https://www.bandwidthplace.com/), [Speedtest](https://www.speedtest.net/), [speedcheck](https://www.speedcheck.org/), [Meter](https://www.meter.net/), [Speedsmart](https://speedsmart.net/)
 
 ***
 
@@ -1271,7 +1271,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 ### IP Leak Tests
 
-[BrowserLeaks](https://browserleaks.com/), [Astrill](https://rentry.co/astrill), [Comparitech](https://www.comparitech.com/privacy-security-tools/dns-leak-test/), [Netease](https://nstool.netease.com/), [Do I leak?](https://www.top10vpn.com/tools/do-i-leak/), [IPLeak](https://ipleak.org/) / [2](https://ipleak.com/) / [3](https://ipleak.net)
+[BrowserLeaks](https://browserleaks.com/), [Astrill](https://rentry.co/astrill), [Comparitech](https://www.comparitech.com/privacy-security-tools/dns-leak-test/), [Do I leak?](https://www.top10vpn.com/tools/do-i-leak/), [IPLeak](https://ipleak.org/) / [2](https://ipleak.com/) / [3](https://ipleak.net)
 
 ### DNS Leak Tests
 
@@ -1285,7 +1285,9 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 ## IP / Network Tools
 
-[2ip.io](https://2ip.io/) / [2](https://2ip.me/) / [3](https://2ip.ru/), [IPVoid](https://www.ipvoid.com/), [Hacker Target](https://hackertarget.com/ip-tools/), [ipaddressguide](https://www.ipaddressguide.com/), [ipfingerprints](https://www.ipfingerprints.com/), [centralops](https://centralops.net/), [networkappers](https://networkappers.com/), [dnstools](http://www.dnstools.ch/), [networkappers](https://networkappers.com/), [ipinfo](https://ipinfo.info), [ViewDNS](https://viewdns.info/), [DNSChecker](https://dnschecker.org/all-tools.php), [Dotcom Tools](https://www.dotcom-tools.com/), [Resolve.rs Tools](https://resolve.rs/tools.html), [Webrate](https://webrate.org/), [Website.informer](https://website.informer.com/), [Network Tools](https://www.broadbandsearch.net/network-tools), [WebsiteScoop](https://websitescoop.com/), [zmap](https://zmap.io/, [web-check](https://web-check.xyz/)
+** ⭐ **[Web Check](https://web-check.xyz/)**
+
+[2ip.io](https://2ip.io/) / [2](https://2ip.me/), [IPVoid](https://www.ipvoid.com/), [Hacker Target](https://hackertarget.com/ip-tools/), [ipaddressguide](https://www.ipaddressguide.com/), [ipfingerprints](https://www.ipfingerprints.com/), [centralops](https://centralops.net/), [networkappers](https://networkappers.com/), [networkappers](https://networkappers.com/), [ipinfo](https://ipinfo.info), [ViewDNS](https://viewdns.info/), [DNSChecker](https://dnschecker.org/all-tools.php), [Dotcom Tools](https://www.dotcom-tools.com/), [Resolve.rs Tools](https://resolve.rs/tools.html), [Webrate](https://webrate.org/), [Website.informer](https://website.informer.com/), [Network Tools](https://www.broadbandsearch.net/network-tools), [WebsiteScoop](https://websitescoop.com/), [zmap](https://zmap.io/)
 
 ***
 


### PR DESCRIPTION
**Changes made:**

- Removed [Xfinity Speed Test](https://speedtest.xfinity.com/), only has servers in the US and doesn't offer that much info anyway, all the tips are very basic, common knowledge stuff

- Removed [DLS Reports](http://www.dslreports.com/tools), pretty unreliable and alt tabbing cancels the speed test

- Removed [wifiman](http://wifiman.com/), admits to collecting information and sharing it with third parties

- Removed [Net Speed Meter](https://www.microsoft.com/en-gb/p/app/9nmbx01pxz4l), there's no need to install an app just for a speedtest + it has pretty low ratings

- Removed [GoogleFiber](http://speedtest.googlefiber.net/), no https and doesn't show much info

- Removed [Speedtest-Tracker](https://github.com/henrywhitaker3/Speedtest-Tracker), overall seems pretty broken and is no longer updated (last update 2 yrs ago and 150 issues open)

- Removed [PeerFast](https://diegorbaquero.github.io/PeerFast/), stuck on test is starting and hasn't been updated in 2 years

- Removed [testmyspeed](https://testmyspeed.onl/), another speedtest developed by Ookla but there's no reason to use it over https://www.speedtest.net/ or fast

- Removed [speedtestcustom](https://pcmag.speedtestcustom.com/), clone of testmyspeed.onl with bright red background :')

- Removed [SpeedOf.Me](https://speedof.me/), doesn't show much info + sponsored by nord so it's heavily advertised on site

- Removed [BroadbandSpeedChecker](https://broadbandspeedchecker.co.uk/), shows significantly slower results than normal and the site is overall pretty bloat with random stuff

- Removed [att](https://www.att.com/support/speedtest/), requires sign-up

- Removed [testmy](https://testmy.net/), pretty awful UI/UX, redirects a shitton during testing

- Removed [CIRA](https://performance.cira.ca/), requires a shitton of info to start the test

- Removed [OpenSpeedTest](https://openspeedtest.com/), pretty much a bloated clone of librespeed

- Removed [speed.io](https://speed.io/), doesn't show much info and meh UI, no reason to use it over everything else

- Removed [Netease](https://nstool.netease.com/), site is in chinese and no longer functional

- Removed [3](https://2ip.ru/), it's the russian version of 2ip, it should be moved to the non-eng russian section

- Removed [dnstools](http://www.dnstools.ch/), site is in german but generally should just be removed since no https

- Starred [Web Check](https://web-check.xyz/) in IP / Network Tools, it does very extensive checks and shows lots of information, is regularly updated, and has a very nice and intuitive UI