### PR TITLE
Update Non-English.md

### DIFF
--- a/Non-English.md
+++ b/Non-English.md
@@ -381,17 +381,15 @@
 * [GoTo10](https://www.goto10.fr/) - BBS and Minitel Archives
 * [DropReference](https://dropreference.com/) - PC Building Site
 * [TrustScam](https://trustscam.fr/) - Website Security Analysis
-* [RedacBox](https://www.redacbox.fr/) - News / Guides for Writers and Entrepreneurs
-* [Portail Orange](https://www.orange.fr/portail) - Seach
 
 ## ▷ Downloading
 
 * ⭐ **[French DDL Google Docs](https://discord.com/invite/AwAcRHXZ5m)** - [Films](https://docs.google.com/document/d/1f-CCNWh_pVSNQhivKEDixndBoM37XslJBR9OJqFeeBA/) / [Series](https://docs.google.com/document/d/1fb2yM3BW7Dn2-ueXldW5IN8EKCEfDQtesCF_xXpYTl0/) / [Anime](https://docs.google.com/document/d/1Bk84UHCvs6pUWL4OkJqgMsdiSkrFeJRmkGOTBlzuI7M/) / [Books](https://docs.google.com/document/d/1uPE4t6QfOxQE8KFl9dkbRmNgGlknDLMEw8bdAI5FMgs/)
 * [NextWarez](https://nextwarez.com/) - Warez Lists
 * [mega-p2p](https://www.mega-p2p.net/) - Warez Lists
-* [Seekr](https://w7w.files-seekr.com/) - Download Search Files
+* [FilesSeekr](https://w7w.files-seekr.com/) - Download Search Files
 * [Pixel Downloader](https://github.com/valentintintin/pixel-downloader) - French / Download Search Tool
-* [WawaCity](https://www.wawacity.bet/) - Video / Audio / Books / Magazines/ Use AdBlocker
+* [WawaCity](https://www.wawacity.kim/) - Video / Audio / Books / Games / Use Adblocker
 * [9docu](https://9docu.org/) - Documentaries
 * [DBFree](http://dbfree.me/) - Books
 * [FRDownMags](https://fr.downmagaz.net/) - Magazines
@@ -402,7 +400,7 @@
 ## ▷ Torrenting
 
 * [YggTorrent](https://www3.yggtorrent.wtf/) - Video / Audio / Roms  / Books  / Comics
-* [Torrent9](https://www.torrent9.fm/), [2](https://www.torrent9.site/), [3](https://torrent9.app/) - Video / Audio/ Roms / Books
+* [Torrent9](https://www.torrent9.fm/), [2](https://www.torrent9.site/), [3](https://torrent9.app/) - Video / Audio / Roms / Books
 * [Torrent911](https://www.torrent911.me/)  - Video / Audio/ Roms / Books
 * [OxTorrent](https://oxtorrents.co/) - Video / Audio/ Roms / Books
 * [Cpasbien](https://www.cpasbien.tw/) - Video / Audio / Books/ ROMs
@@ -413,26 +411,19 @@
 ## ▷ Streaming
 
 * ⭐ **[Sadisflix](https://sadisflix.day/)** - Movies / TV / [Telegram](https://t.me/sadisflix)
-* [WawaCity](https://www.wawacity.bet/) - Video / Audio / Books / Magazines/ Use Adblocker
-* [kinoger](https://kinoger.com/), [2](https://www.kinoger.to/) - Movies / TV / Anime
-* [quedustreaming](https://wawa-streams.com/) - Movies / TV / Anime
-* [MesFilms](https://mesfilms.sbs/) - Movies / TV / Anime
-* [hds](https://www1.hds.fm/) - Movies / TV / Anime
-* [voirfilms-hd](https://flashfilms-hd.top/) - Movies / TV
-* [Cinematheque](https://www.cinematheque-bretagne.bzh/) - Movies
+* [MesFilms](https://mesfilms.sbs/), [HDS](https://www1.hds.fm/), [VoirFilmsHD](https://flashfilms-hd.top/) - Movies / TV / Cartoons / Anime
+* [Wawa-Streams](https://wawa-streams.com/) - Movies / TV
+* [Cinematheque](https://www.cinematheque-bretagne.bzh/) - Classic / Amateur Movies
 * [OtakuFR](https://otakufr.co/) - Anime
-* [JetAnime](https://vww.jetanimes.com/) - Anime
 * [Anime-Ultime](http://www.anime-ultime.net/), [2](https://v5.anime-ultime.net/) - Anime
-* [universanime](https://www.universanime.co/) - Anime
+* [universanime](https://www.universanime.club/) - Anime
 * [mavanimes](https://mavanimes.cc/) - Anime
 * [FRAnime](https://franime.fr/) - Anime
 * [French Anime](https://french-anime.com/) - Anime
 * [VoirAnime](https://voiranime.com/) - Anime
-* [Animevost.fr](https://animevost.fr/) - Anime
 * [Neko-sama](https://www.neko-sama.fr/) - Anime
 * [Animeo TV](https://animeovf.fr) - Anime
 * [sekai](https://sekai.one/) - Anime
-* [senpai](https://senpai.cc/) - Anime
 * [vostanime](https://vostanime.fr/) - Anime
 * [VostFree](https://vostfree.ws/) - Anime
 * [animevostfr](https://animevostfr.tv/) - Anime
@@ -441,20 +432,17 @@
 * [anime-sama](https://anime-sama.fr/) - Anime
 * [toonanime](https://v2.toonanime.tv/) - Anime
 * [VoirCartoon](https://voircartoon.com/) - Cartoons
-* [liveschauen](https://deutschekanale.com/) - Live TV
-* [ADKami](https://www.adkami.com/) - French Anime Calendar
 * [33rapmp3](https://www.33rapmp3.cc/) - Rap
 
 ## ▷ Reading
 
 * [BookDDL](http://www.bookddl.com/) - Books / Magazines / Newspapers / Audiobooks
 * [Bookys](https://ww8.bookys-ebooks.com/) - Books / Comics / Magazines / Newspapers / NSFW
-* [1001ebooks](https://1001ebooks.net/) - Books
 * [Planet-DB](https://planete-bd.org/) - Comics / Manga
 * [Audiocite](https://www.audiocite.net/) - Audiobooks
 * [zone-ebook.com](https://zone-ebook.com/) - Magazines / Newspapers / Books / Audiobooks / Comics
 * [nooSFere](https://www.noosfere.org/) - Science Fiction
-* [Rigines](https://discord.com/invite/origines) - Manga / Manhwa / Manhua / NSFW
+* [Origines](https://discord.com/invite/origines) - Manga / Manhwa / Manhua / NSFW
 * [japscan](https://www.japscan.lol/) - Manga
 * [scan-fr](https://www.scan-fr.org/) - Manga
 * [mangascan](https://manga-scan.co/), [2](https://scansmangas.me/), [3](https://scanmanga-vf.ws/) - Manga


### PR DESCRIPTION
**Changes made:**

- Removed [ADKami](https://www.adkami.com/) - redirects to crunchyroll and other paid sites

- Removed [kinoger](https://kinoger.com/), [2](https://www.kinoger.to/), isn't french

- Removed [WawaCity](https://www.wawacity.bet/) from streaming section since it's for downloading, also updated the domain for wawacity in downloading

- Removed [JetAnime](https://vww.jetanimes.com/), domain expired

- Removed [Animevost.fr](https://animevost.fr/), redirects to random DC link

- Removed [senpai](https://senpai.cc/) and [liveschauen](https://deutschekanale.com/), not french

- Removed [Portail Orange](https://www.orange.fr/portail), paid media "seach"

- Removed [RedacBox](https://www.redacbox.fr/), not very useful, niche, and doesn't appear to be updated anymore

- Removed [1001ebooks](https://1001ebooks.net/), ublock blocks all download links