### PR TITLE
Update STORAGE.md

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -3077,14 +3077,14 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 * ⭐ **[Wallpaper Abyss](https://wall.alphacoders.com/)**
 * ⭐ **[Studio Ghibli Wallpapers](https://www.ghibli.jp/info/013772)**
 * [CoolBackgrounds](https://coolbackgrounds.io/) or [wallup](https://wallup.net/) - Customizable Wallpapers
-* [simpledesktops](http://simpledesktops.com/), [Positron Dream](https://www.positrondream.com/) or [setaswall](https://www.setaswall.com/) - Minimalistic Wallpapers
+* [Simple Desktops](http://simpledesktops.com/), [Positron Dream](https://www.positrondream.com/) or [SetAsWall](https://www.setaswall.com/) - Minimalistic Wallpapers
 * [DualMonitorBackgrounds](https://www.dualmonitorbackgrounds.com/) or [WallpaperFusion](https://www.wallpaperfusion.com/) - Dual Monitor Wallpapers
 * [Xbox Wallpapers](https://www.xbox.com/en-us/wallpapers/) - Game Wallpapers
 * [99images](https://www.99images.com/) - Celebrity Wallpapers
 * [Dracula Wallpapers](https://draculatheme.com/wallpaper) - Dracula Themes
 * [Mac Wallpapers](https://goo.gl/photos/HjY1hmo6p3jfFz8a7), [2](https://photos.google.com/share/AF1QipNNQyeVrqxBdNmBkq9ILswizuj-RYJFNt5GlxJZ90Y6hx0okrVSLKSnmFFbX7j5Mg?key=RV8tSXVJVGdfS1RIQUI0Q3RZZVhlTmw0WmhFZ2V3) - Mac Themes
 
-[WallpaperAccess](https://wallpaperaccess.com/), [Wallpapers.com](https://wallpapers.com/), [Wallpaper Safari](https://wallpapersafari.com/), [WallpaperCave](https://wallpapercave.com/), [GetWalls](https://getwalls.io/), [vlad.studio](https://vlad.studio/wallpapers/?sort=free&filter=all), [Microsoft Wallpapers](https://wallpapers.microsoft.design/), [WallpaperHub](https://wallpaperhub.app/), [Wallpaper Tip](https://wallpapertip.com/), [WallpaperFlare](https://www.wallpaperflare.com/), [hdqwalls](https://hdqwalls.com/), [uhdpaper](https://www.uhdpaper.com/), [wallpapersden](https://wallpapersden.com/), [vsthemes](https://vsthemes.org/en/pictures/), [wallpaperscraft](https://wallpaperscraft.com/), [backiee](https://backiee.com/), [hdwallpapers](https://www.hdwallpapers.in/), [wallpaper-house](https://wallpaper-house.com/), [pixelstalk](https://www.pixelstalk.net/), [7-themes](http://7-themes.com/), [gettywallpapers](http://m.gettywallpapers.com/), [wallpaperset](https://wallpaperset.com/), [wallpapershome](https://wallpapershome.com/), [teahub](https://www.teahub.io/), [wallpaperbetter](https://www.wallpaperbetter.com/), [wallpapercrafter](https://wallpapercrafter.com/), [wallpapersmug](https://wallpapersmug.com/), [wallup](https://wallup.net/), [peakpx](https://www.peakpx.com/), [itl](https://www.itl.cat/), [pixel4k](https://www.pixel4k.com/), [wallha](https://wallha.com/), [4kwallpapers](https://4kwallpapers.com/), [wallpaperswide](https://wallpaperswide.com/)
+[WallpaperAccess](https://wallpaperaccess.com/), [Wallpapers.com](https://wallpapers.com/), [WallpaperSafari](https://wallpapersafari.com/), [WallpaperCave](https://wallpapercave.com/), [GetWalls](https://getwalls.io/), [vlad.studio](https://vlad.studio/wallpapers/?sort=free&filter=all), [Microsoft Wallpapers](https://wallpapers.microsoft.design/), [WallpaperHub](https://wallpaperhub.app/), [Wallpaper Tip](https://wallpapertip.com/), [WallpaperFlare](https://www.wallpaperflare.com/), [HDQwalls](https://hdqwalls.com/), [UHD Wallpaper](https://www.uhdpaper.com/), [Wallpapersden](https://wallpapersden.com/), [vsthemes](https://vsthemes.org/en/pictures/), [WallpapersCraft](https://wallpaperscraft.com/), [backiee](https://backiee.com/), [HD Wallpapers](https://www.hdwallpapers.in/), [Wallpaper-House](https://wallpaper-house.com/), [pixelstalk](https://www.pixelstalk.net/), [7-Themes](http://7-themes.com/), [Gettywallpapers](http://m.gettywallpapers.com/), [Wallpaperset](https://wallpaperset.com/), [Wallpapershome](https://wallpapershome.com/), [teahub](https://www.teahub.io/), [Wallpapercrafter](https://wallpapercrafter.com/), [WallpapersMug](https://wallpapersmug.com/), [Peakpx](https://www.peakpx.com/), [itl](https://www.itl.cat/), [pixel4k](https://www.pixel4k.com/), [wallha](https://wallha.com/), [4kwallpapers](https://4kwallpapers.com/), [WallpapersWide](https://wallpaperswide.com/)
 
 ### Telegram Wallpaper Channels
 
@@ -3094,32 +3094,28 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 * ⭐ **[LWP](https://github.com/jszczerbinsky/lwp)** - Move Wallpapers with Cursor
 * [AutoWall](https://github.com/SegoCode/AutoWall) - Turn Videos / GIFs to Live Wallpapers
-* [N0va](https://n0vadp.hoyoverse.com), [wallpaperwaifu](https://wallpaperwaifu.com/) or [MyLiveWallpapers](https://mylivewallpapers.com/) - Anime Wallpapers
+* [N0va](https://n0vadp.hoyoverse.com), [WallpaperWaifu](https://wallpaperwaifu.com/) or [MyLiveWallpapers](https://mylivewallpapers.com/) - Anime Wallpapers
 * [Scenic Illustrations](https://www.pixeltrue.com/scenic-illustrations) - Landscape Wallpapers
 
 [/r/LivingBackgrounds](https://reddit.com/r/LivingBackgrounds), [WALLegend](https://wallegend.net/en/), [MoeWalls](https://moewalls.com/)
 
 ### Wallpaper Managers
 
-* ⭐ **[Wallpaper Engine](https://github.com/nbats/FMHYedit/blob/main/base64.md##wallpaper-engine)**
-* ⭐ **Wallpaper Engine** - [PKG to Zip](https://github.com/TheRioMiner/Wallpaper-Engine-Pkg-to-Zip) / [Collections](https://www.wallpaperengine.space/collections), [2](https://steamcommunity.com/sharedfiles/filedetails/?id=2801058904)
-* [Wallery](https://github.com/metafates/Wallery) - Display Wallpapers
+* ⭐ **[Wallpaper Engine](https://github.com/nbats/FMHYedit/blob/main/base64.md##wallpaper-engine)** / [PKG to Zip](https://github.com/TheRioMiner/Wallpaper-Engine-Pkg-to-Zip) / [Collections](https://www.wallpaperengine.space/collections), [2](https://steamcommunity.com/sharedfiles/filedetails/?id=2801058904)
 * [Faerber](https://farbenfroh.io/faerber) - Edit Wallpaper to Match Color Scheme
 
-[ScreenPlay](https://screen-play.app/), [backiee](https://apps.microsoft.com/store/detail/backiee-wallpaper-studio-10/9WZDNCRFHZCD), [Daily Reddit Wallpaper](https://github.com/ssimunic/Daily-Reddit-Wallpaper), [Daily Bing Wallpaper](https://github.com/sfn101/bing-daily-lively-wallpaper), [Awesome Wallpaper](https://awesome-wallpaper.com/), [tanck.nl](https://tanck.nl/wallpaper/), [SuperPaper](https://github.com/hhannine/superpaper)
+[ScreenPlay](https://screen-play.app/), [backiee](https://apps.microsoft.com/store/detail/backiee-wallpaper-studio-10/9WZDNCRFHZCD), [Daily Bing Wallpaper](https://github.com/sfn101/bing-daily-lively-wallpaper), [Awesome Wallpaper](https://awesome-wallpaper.com/), [SuperPaper](https://github.com/hhannine/superpaper)
 
 ### Mobile Wallpapers
 
 * ⭐ **[Mobile Abyss](https://mobile.alphacoders.com/)**
-* [Darkinator](https://play.google.com/store/apps/details?id=com.tfuerholzer.darkmodewallpaper) - Change Wallpaper Depending on System Theme
-* [wallpaperwaifu](https://wallpaperwaifu.com/), [Muzei](https://github.com/muzei/muzei), [Chroma Galaxy](https://play.google.com/store/apps/details?id=com.at2_software.terracollageapp), [Doodle](https://patrickzedler.com/doodle/), [GIFLiveWallpaper](https://play.google.com/store/apps/details?id=com.awesome.giflivewallpaper), [AnyVideo](https://play.google.com/store/apps/details?id=com.mclwp.anyvideolivewallpaper), [Ornamental](https://play.google.com/store/apps/details?id=com.lazybonesgames.ornamentaltheapp), [Reddit Wallpaper](https://play.google.com/store/apps/details?id=com.bryanwalsh.redditwallpaper2), [Amoled Backgrounds](https://play.google.com/store/apps/details?id=com.droidheat.amoledbackgrounds) or [LiveLoop](https://play.google.com/store/apps/details?id=com.wallpaper.liveloop) - Live Android Wallpapers
-* [DualWallpaper](https://github.com/Yanndroid/DualWallpaper) - Auto Switch Light / Dark Mode Wallpapers
-* [koncius](https://play.google.com/store/apps/details?id=com.koncius.video.wallpaper) - Android Video to Wallpaper
-* [Canvas-Downlaoder](https://www.canvasdownloader.com/) - Spotify Canvas Wallpapers 
-* [WallClaimer](https://www.wallclaimer.com/) - Snag Friends Wallpapers
-* [Das Image](https://apps.apple.com/ca/app/das-image-search-and-explore/id1464079804) - iOS Wallpaper App
+* [Darkinator](https://play.google.com/store/apps/details?id=com.tfuerholzer.darkmodewallpaper) or [DualWallpaper](https://github.com/Yanndroid/DualWallpaper) - Change Wallpaper Depending on System Theme
+* [Muzei](https://github.com/muzei/muzei), [Doodle](https://patrickzedler.com/doodle/) or [Amoled Backgrounds](https://play.google.com/store/apps/details?id=com.droidheat.amoledbackgrounds) - Live Android Wallpapers
+* [Koncius](https://play.google.com/store/apps/details?id=com.koncius.video.wallpaper) - Android Video to Wallpaper
+* [Das Image](https://apps.apple.com/ca/app/das-image-search-and-explore/id1464079804), [iPhone11papers](https://iphone11papers.com/) or [iOS Wallpapers](https://goo.gl/photos/ZVpabTtcezd35XBa9/) - iOS Wallpapers
+* [/r/iWallpaper](https://www.reddit.com/r/iWallpaper/) or [/r/MobileWallpaper](https://www.reddit.com/r/MobileWallpaper/) - Mobile Wallpapers Subreddits
 
-[Wallpaper Engine](https://www.wallpaperengine.io/android/en), [wallhaven](https://wallhaven.cc/search?categories=110&purity=100&ratios=portrait), [wallpaperfusion](https://www.wallpaperfusion.com/Apps/), [wallpaperaccess](https://wallpaperaccess.com/cat/devices), [wallpapers.com](https://wallpapers.com/mobile), [wallpapersafari](https://wallpapersafari.com/), [wallpapercave](https://wallpapercave.com/categories/devices), [positrondream](https://www.positrondream.com/wallpapers-all), [simpledesktops](http://simpledesktops.com/app/android/), [wallpapertip](https://www.wallpapertip.com/), [wallpaperflare](https://www.wallpaperflare.com/search?wallpaper=vertical), [hdqwalls](https://hdqwalls.com/), [wallpapersden](https://wallpapersden.com/), [iOS Wallpapers](https://goo.gl/photos/ZVpabTtcezd35XBa9/) / [2](https://photos.google.com/share/AF1QipNi8VN2pw2Ya_xCV8eFgzEZmiXDy1-GwhXbqFtvXoH3HypF10as9puV8FdoVZpOZA?key=WkZjQTIxQTM5a01oZkNUYTE2ZllKTVJKZk1CMTR3), [VectorifyDaHome](https://github.com/enricocid/VectorifyDaHome), [backiee](https://backiee.com/), [Wallpapers_Phone_Mobile](https://t.me/Wallpapers_Phone_Mobile/), [iphone11papers](https://iphone11papers.com/), [Wallpapers Clan](https://wallpapers-clan.com/), [WallYou](https://github.com/Bnyro/WallYou), [Mobcup](https://mobcup.net/), [Absolutely Walls](https://photos.app.goo.gl/CxHuPTVjmPUSu2sUA), [/r/iWallpaper](https://www.reddit.com/r/iWallpaper/), [WalliApp](https://www.walliapp.com/), [/r/Verticalwallpapers](https://www.reddit.com/r/Verticalwallpapers/), [/r/MobileWallpaper](https://www.reddit.com/r/MobileWallpaper/), [Zedge](https://www.zedge.net/), [Wallman](https://apt.izzysoft.de/fdroid/index/apk/com.colorata.wallman)
+[Wallpapers Clan](https://wallpapers-clan.com/), [Wallpaper Engine](https://www.wallpaperengine.io/android/en), [WallpaperFusion](https://www.wallpaperfusion.com/Apps/), [Wallpapers.com](https://wallpapers.com/mobile), [Wallpaper Flare](https://www.wallpaperflare.com/search?wallpaper=vertical), [HDQwalls](https://hdqwalls.com/), [Wallpapersden](https://wallpapersden.com/), [VectorifyDaHome](https://github.com/enricocid/VectorifyDaHome), [WallYou](https://github.com/Bnyro/WallYou), [MobCup](https://mobcup.net/), [Absolutely Wallpapers](https://photos.app.goo.gl/CxHuPTVjmPUSu2sUA), [WalliApp](https://www.walliapp.com/), [Zedge](https://www.zedge.net/), [WallMan](https://apt.izzysoft.de/fdroid/index/apk/com.colorata.wallman)
 
 ***
 


### PR DESCRIPTION
**Changes made:**

- Debloated remaining wallpapers sections
- Added some descriptions and merged some stuff that fit the same desc
- Updated some names
- Removed [Wallery](https://github.com/metafates/Wallery), repo archived, only 6 stars and not maintained anymore
- Removed [Daily Reddit Wallpaper](https://github.com/ssimunic/Daily-Reddit-Wallpaper), doesn't work anymore and no longer maintained
- Removed [tanck.nl](https://tanck.nl/wallpaper/), not a wallpaper manager and its no longer maintained
- Removed [Chroma Galaxy](https://play.google.com/store/apps/details?id=com.at2_software.terracollageapp), live wallpapers just loop and don't have good animation / quality
- Removed [GIFLiveWallpaper](https://play.google.com/store/apps/details?id=com.awesome.giflivewallpaper), have to reapply the wallpaper every few days because it resets
- Removed [Ornamental](https://play.google.com/store/apps/details?id=com.lazybonesgames.ornamentaltheapp), have to watch ads to unlock any wallpapers
- Removed [AnyVideo](https://play.google.com/store/apps/details?id=com.mclwp.anyvideolivewallpaper), appears to have a shitton of bugs and doesn't work for a lot of people
- Removed [Reddit Wallpaper](https://play.google.com/store/apps/details?id=com.bryanwalsh.redditwallpaper2), last update 2021 and doesn't work anymore
- Removed [LiveLoop](https://play.google.com/store/apps/details?id=com.wallpaper.liveloop), have to watch ads to unlock any wallpaper
- Removed [Canvas-Downlaoder](https://www.canvasdownloader.com/), not exclusive for mobile and it should be moved to spotify tools since it fits there better, it has a lot more use cases than just using it to get wallpapers
- Removed [WallClaimer](https://www.wallclaimer.com/), has very strict and unreliable filters
- Removed [wallhaven](https://wallhaven.cc/search?categories=110&purity=100&ratios=portrait) from the mobile wallpapers section, it's already starred in wallpapers and not exclusively for mobile
- Removed [wallpaperaccess](https://wallpaperaccess.com/cat/devices), [wallpapersafari](https://wallpapersafari.com/), [positrondream](https://www.positrondream.com/wallpapers-all), [wallpapertip](https://www.wallpapertip.com/) and [backiee](https://backiee.com/) from mobile wallpapers, it's already in wallpapers section and mostly just has wallpapers for desktops
- Removed [wallpapercave](https://wallpapercave.com/categories/devices) from mobile wallpapers, doesn't have that much stuff for mobile and it's mostly just default wallpapers for different phones
- Removed [simpledesktops](http://simpledesktops.com/app/android/) from mobile wallpapers, play store link is dead
- Removed [Wallpapers_Phone_Mobile](https://t.me/Wallpapers_Phone_Mobile/), it's now a tg for buying insta followers
- Removed [/r/Verticalwallpapers](https://www.reddit.com/r/Verticalwallpapers/), went private
- Removed [wallpaperbetter](https://www.wallpaperbetter.com/), changing lang to english just redirects it to wallpaperflare which we already have in the wiki