### PR TITLE
Update replace.py

### DIFF
--- a/.github/replace.py
+++ b/.github/replace.py
@@ -88,7 +88,7 @@ def reformat_subsections(text):
     text = re.sub('#wiki_', '/#', text)
     text = re.sub('.25BA_', '', text)
     text = re.sub('.25B7_', '', text)
-    text = re.sub('_.2F_', '--', text)
+    text = re.sub('_.2F_', '-', text)
     text = replace_underscore(text)
     return text
 


### PR DESCRIPTION
Fix internal links that lead to Headers that contain " / "

For example in https://fmhy.net/toolsguide#text-tools when clicking on "Note Taking / To-Do" it doesnt lead to the correct subsection