### PR TITLE
change homepage "browse collection" link to beginners-guide

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ hero:
   actions:
     - theme: brand
       text: Browse Collection
-      link: /adblockvpnguide
+      link: /beginners-guide
     - theme: alt
       text: Discord
       link: https://discord.gg/Stz6y6NgNg


### PR DESCRIPTION
it currently links to adblockvpnguide, i think the beginners guide makes a lot more sense and is more relevant to the average new user