### PR TITLE
Update Non-English.md

### DIFF
--- a/Non-English.md
+++ b/Non-English.md
@@ -866,44 +866,39 @@
 
 ***
 
+
 # ► Polish
 
-* [Sport TVP](https://sport.tvp.pl/) - Sports News
+* [FilmPolski](https://filmpolski.pl/fp/index.php) - Polish Video Archive
 
 ## ▷ Downloading
 
-* [Dark Machine](https://darkmachine.pl/) - Video / Audio/ Books / Audiobooks / NSFW
-* [animezone](https://www.animezone.pl/) - Anime
+* [animezone](https://www.animezone.pl/) - Anime / Sub / 720p
 
 ## ▷ Torrenting
 
-* [polskie-torrenty](https://polskie-torrenty.net.pl/) - Video / Audio/ Books / NSFW
-* [devil-torrents](https://devil-torrents.pl/) - Video / Audio/ Books / NSFW
-* [PolishSource](https://polishsource.cz/)
+* [polskie-torrenty](https://polskie-torrenty.net.pl/) - Video / Audio / Books / NSFW
+* [devil-torrents](https://devil-torrents.pl/) - Video / Audio / Books / NSFW
 
 ## ▷ Streaming
 
-* [cda-hd](https://cda-hd.cc/) - Movies / TV
-* [filman.cc](https://filman.cc/) - Movies / TV
-* [Ekino-TV](https://ekino-tv.pl/) - Movies / TV
-* [Zerion.cc](https://zerion.cc/) - Movies / TV
-* [Vizjer](https://vizjer.pl/) - Movies / TV
-* [Zerknij](https://zerknij.tv/) - Movies / TV
-* [Kinomoc](https://kinomoc.com/) - Movies / TV
-* [Filser](https://filser.cc/) - Movies / TV
-* [iiTV](https://iitv.info/) - TV / Cartoons
-* [OpenClip](http://openclip.info/) - Movies / TV / Anime
-* [Shinden](https://shinden.pl/) - Anime / [Discord](https://discord.gg/xyH5uS6)
-* [Anime Odcinki](https://anime-odcinki.pl/) - Anime
-* [FilmPolski](https://filmpolski.pl/fp/index.php) - Polish Video Archive
+* [Kinomoc](https://kinomoc.com/) - Movies / TV / Dub / 1080p
+* [cda-hd](https://cda-hd.cc/) - Movies / TV / Cartoons / Dub / 720p
+* [Zerion](https://zerion.cc/) - Movies / TV / Cartoons / Dub / 720p
+* [Filser](https://filser.cc/) - Movies / TV / Cartoons / Dub / 720p
+* [Vizjer](https://vizjer.pl/) - Movies / TV / Dub / 720p
+* [Zerknij](https://zerknij.tv/) - Movies / TV / Dub / 720p
+* [Ekino-TV](https://ekino-tv.pl/) - Movies / TV / Sub / 720p
+* [iiTV](https://iitv.info/) - TV / Cartoons / Dub / 720p
+* [Anime Odcinki](https://anime-odcinki.pl/) - Anime / Sub / 1080p
+* [Shinden](https://shinden.pl/) - Anime / Sub / 1080p / [Discord](https://discord.gg/xyH5uS6)
+* [Sport TVP](https://sport.tvp.pl/) - Live Sports
 
 ## ▷ Reading
 
-* [wolnelektury](https://wolnelektury.pl/) - Books / Fiction
+* [wolnelektury](https://wolnelektury.pl/) - Books / Fiction / Audiobooks
 * [Audiobook PL](https://audiobookpl.tumblr.com/) - Audiobooks
-* [K1n013f0ur's Pastebin](https://github.com/nbats/FMHYedit/blob/main/base64.md#k1n013f0urs-pastebin) - Audiobooks
-* [doci.pl](https://doci.pl/) - Documents
-* [docer.pl](https://docer.pl/) - Documents
+* [Doci.pl](https://doci.pl/) - Educational / Documents
 * [Academica](https://academica.edu.pl/) - Online Library
 
 ***
@@ -912,40 +907,33 @@
 
 * 🌐 **[Guia de Pirataria para Iniciantes](https://rentry.org/PiracyBG-PTBR)** - Portuguese Beginners Guide to Piracy
 * 🌐 **[Portuguese Piracy Sites](https://rentry.org/PortuguesePiracySites)** - Portuguese Piracy Sites
-* [Invertexto](https://www.invertexto.com) - Multiple Online Tools
+* 🌐 **[Invertexto](https://www.invertexto.com)** - Online Tools Index
 * [SAPO](https://www.sapo.pt) - Search
-* [Legendei.TV](https://legendei.tv), [Legendas.net](https://legendas.net), [Legenda Oficial](http://legendaoficial.net), [Legendas](https://legendas.co) or [Legendas Zone](https://www.legendas-zone.org) - Subtitles
 * [Legendas Brasil](https://legendasbrasil.org) - Subtitle Search App
-* [MD.Saúde](https://www.mdsaude.com) or [Tua Saúde](https://www.tuasaude.com) - Health News
-* [Dieta Emagrece](https://dietaemagrece.com.br) or [Beleza e Saúde](https://belezaesaude.com) - Health
-* [NONIOBlocker](https://github.com/DevTiagoCruz/NONIOBlocker) - News Site Adblocker
+* [Legendei.TV](https://legendei.tv), [Legendas.net](https://legendas.net), [Legenda Oficial](http://legendaoficial.net) or [Legendas](https://legendas.co) - Subtitles
 * [Educa Mais Brasil](https://www.educamaisbrasil.com.br/enem/guia-enem) - ENEM Study Material
 * [Universia](https://www.universia.net) - Portuguese University Search
 * [Flutterando](https://github.com/Flutterando/roadmap) - Flutter Guides
 * [Escola Kids](https://escolakids.uol.com.br) - Kids Learning
 * [Atari2600](https://www.atari2600.com.br) - Browser Emulator
 * [Racha Cuca](https://rachacuca.com.br) - Puzzles / Trivia
-* [Plagiarisma](https://plagiarisma.net/pt/) - Plagiarism Checker
-* [Gerador de Nomes de Fantasia](https://www.nomesdefantasia.com) - Fantasy Name Generator
-* [CatálogoApp](https://catalogoapp.mobi) - Portuguese Product Catalog
-* [Dicionário MPB](https://dicionariompb.com.br) - Top Song Charts
 * [Jogorama](https://jogorama.com.br) - Game Index / Tips
-* [Arquivo.pt](https://arquivo.pt) - History / Sociology / Linguistics Archives
+* [Dicionário MPB](https://dicionariompb.com.br) - Top Song Charts
 
 ## ▷ Downloading
 
 * ⭐ **[WR Educacional](https://www.wreducacional.com.br)** - Courses
-* [Rei dos Torrents](https://reidostorrents.com) - Video / Audio/ Books
-* [Os Reformados](https://osreformados.com) - Video / Audio / Magazines
-* [Baixar Séries MP4](https://baixarseriesmp4.eu) - Movies / TV / Anime
-* [Animes Totais](https://www.animestotais.xyz) - Movies / TV / Anime / Cartoons
-* [Séries Empire](https://seriesempire.com) - TV
-* [KSensei](https://karinsensei.com) - Anime
-* [Anipakku](https://anipakku.blogspot.com) - Anime / [Discord](https://discord.com/invite/Whu6RV9Gad)
-* [Baixar Vídeo](https://baixarvideo.com.br) - Portuguese Video Downloader
+* [Rei dos Torrents](https://reidostorrents.com) - Video / Audio / Books / Sub / Dub / 1080p
+* [Os Reformados](https://osreformados.com) - Video / Audio / Magazines / Sub / Dub / 1080p
+* [Baixar Séries MP4](https://baixarseriesmp4.eu) - Movies / TV / Anime / Sub / Dub / 1080p
+* [Animes Totais](https://www.animestotais.xyz) - Movies / TV / Anime / Cartoons / Sub / Dub / 1080p
+* [Séries Empire](https://seriesempire.com) - TV / Sub / Dub / 720p
+* [Anipakku](https://anipakku.blogspot.com) - Anime / Sub / 1080p / [Discord](https://discord.com/invite/Whu6RV9Gad)
+* [KSensei](https://karinsensei.com) - Anime / Sub / 720p
+* [Baixar Vídeo](https://baixarvideo.com.br) - Video Downloader
 * [Online Cursos Gratuitos](https://onlinecursosgratuitos.com) - Courses
 * [Escola Educação](https://escolaeducacao.com.br/estude-gratis) - Courses
-* [Mundo Ubuntu](https://www.mundoubuntu.com.br) - Courses
+* [Mundo Ubuntu](https://www.mundoubuntu.com.br) - Courses / Tech Guides
 
 ## ▷ Torrenting
 
@@ -954,35 +942,31 @@
 * [Filmes Grátis](https://filmesgratis.net) - Movies / TV
 * [Torrent dos Filmes](https://torrentdosfilmes.se) - Movies / TV
 * [Comando](https://comando.la) - Movies / TV
-* [tugaflix](https://tugaflix.best) - Movies / TV / Use Adblock
 * [Filmes Mega](https://filmesmega.co) - Movies / TV
 * [Mega Torrents](https://megatorrents.co) - Movies / TV
 * [Filmes Épicos](http://www.filmesepicos.com) - Movies
-* [Download Cult](http://downloadcult.org) - "Cult" Movies
+* [Download Cult](http://downloadcult.org) - Classic Movies
 * [Dark Animes](https://darkmahou.org) - Anime
 * [Anime No Sekai](https://www.ansktracker.net) - Anime WebIRC Tracker
-* [Sua Música](https://www.suamusica.com.br) - MP3
+* [Sua Música](https://www.suamusica.com.br) - Audio / MP3
 * [Livros e Cursos Download](https://timaterial.blogspot.com) - Courses
 
 ## ▷ Streaming
 
-* ⭐ **[Gyn Cursos](https://gyncursos.com.br)** - Courses
-* ⭐ **[iEstudar Cursos](https://iestudar.com)** - Courses
-* ⭐ **[Pensar Cursos](https://www.pensarcursos.com.br)** - Courses
-* [WarezCDN](https://warezcdn.com) - Movies / TV / Anime / API
-* [Vizer](https://vizer.tv) - Movies / TV / Anime
-* [SuperTela](https://supertela.gripe) - Movies / TV / Anime
-* [Quero Filmes HD](https://querofilmeshd.top) - Movies / TV
-* [TopFlix](https://topflix.tv) - Movies / TV
-* [GoFilmes](https://gofilmes.me/m/) - Movies / TV
-* [Os Teus Filmes Tuga](https://osteusfilmestuga.online) - Movies / TV / Anime / Cartoons
-* [tugaflix](https://tugaflix.best) Movies / TV / Use Adblock
-* [Filmes Online HD](https://www.filmesonlinehdgratis.com.br) - Movies / TV
+* ⭐ **[Gyn Cursos](https://gyncursos.com.br)**, **[iEstudar Cursos](https://iestudar.com)** or **[Pensar Cursos](https://www.pensarcursos.com.br)** - Courses
+* [WarezCDN](https://warezcdn.com) - API for Movies / TV / Anime
+* [Vizer](https://vizer.tv) - Movies / TV / Anime / Sub / Dub / 1080p
+* [SuperTela](https://supertela.zip) - Movies / TV / Anime / Dub / 1080p
+* [GoFilmes](https://gofilmes.me/m/) - Movies / TV / Sub / Dub / 1080p
+* [Os Teus Filmes Tuga](https://osteusfilmestuga.online) - Cartoons / 1080p
+* [tugaflix](https://tugaflix.best) Movies / TV / Sub / 1080p
+* [Quero Filmes HD](https://querofilmeshd.top) - Movies / TV / Sub / Dub / 720p
+* [Filmes Online HD](https://www.filmesonlinehdgratis.com.br) - Movies / TV / Sub / 720p
+* [99](https://www.99.media/pt/) - Documentaries / Sub / 1080p
+* [Libreflix](https://libreflix.org) - Portuguese TV / Documentaries / 720p
+* [NewZect](https://newzect.com) - Asian Drama / Sub / 720p
 * [NetMovies](https://www.netmovies.com.br) - Movies / TV / Requires Login
 * [Bombozila](https://bombozila.com) - Movies / TV / Requires Login
-* [Libreflix](https://libreflix.org) - Movies / TV
-* [NewZect](https://newzect.com) - Asian Drama
-* [99](https://www.99.media/pt/) - Documentaries
 * [Ver Futebol TV](https://verfutebol.online) - Live Sports
 * [Olhos na TV](https://www.olhosnatv.com.br) - Live TV / Sports
 * [Assistir TV Online Grátis](https://aovivo.pro/onde/) - Live TV / Sports
@@ -1005,7 +989,8 @@
 * [Escola Virtual](https://www.ev.org.br) - Courses
 * [Veduca](https://veduca.org) - Courses
 * [DIO](https://www.dio.me) - Development Courses
-* [Palco MP3](https://www.palcomp3.com.br) - Music
+* [Palco MP3](https://www.palcomp3.com.br) - Music / MP3
+* [Harpa Cristã](https://harpacrista.org), [2](https://apps.microsoft.com/store/detail/harpa-crist%C3%A3/9WZDNCRDPDWC), [3](https://play.google.com/store/apps/details?id=br.com.masterapps.harpacristagratis) - Christian Music / MP3
 * [Rádio J-Hero](https://radiojhero.com) - Radio
 * [Radios.com.br](https://www.radios.com.br) - Radio
 * [Radiosaovivo.net](https://radiosaovivo.net) - Radio
@@ -1022,7 +1007,6 @@
 * [Rádios7](http://www.radios7.com) - Radio
 * [Antena 1](https://www.antena1.com.br) - Radio
 * [CXRadio](https://www.cxradio.com.br) - Radio
-* [Harpa Cristã](https://harpacrista.org), [2](https://apps.microsoft.com/store/detail/harpa-crist%C3%A3/9WZDNCRDPDWC), [3](https://play.google.com/store/apps/details?id=br.com.masterapps.harpacristagratis) - Christian Music
 * [Flow Podcast](https://nv99.com.br/flow) - Political Podcast
 * [99Vidas](https://99vidas.com.br/) - Gaming Podcast
 * [cinematório](https://www.cinematorio.com.br) - Movie Podcasts
@@ -1032,7 +1016,6 @@
 * [Papo de Gordo](https://www.papodegordo.com.br/category/podcast/) - Podcasts
 * [Mundo Podcast](https://mundopodcast.com.br) - Podcasts
 * [Kboing FM](https://www.kboingfm.com.br/podcast/) - Podcasts
-* [TV Aberta](https://apkpure.com/br/tv-aberta-lite/tv.aberta.lite) - Live TV APK
 * [Tastemade](https://www.tastemade.com.br) - Recipe Videos
 
 ## ▷ Reading
@@ -1087,6 +1070,7 @@
 * [Estudos Bíblicos](https://estudos-biblicos.net), [2](https://estudos-biblicos.blogspot.com) - Bible Studies
 * [Apologeta](https://www.apologeta.com.br) - Bible Commentary
 * [biblia.com.br](https://biblia.com.br) or [iGuga](https://www.iguga.org) - Biblical Dictionary
+* [Arquivo.pt](https://arquivo.pt) - History / Sociology / Linguistics Archives
 
 ***
 


### PR DESCRIPTION
**Changes made:**

- Added video quality and sub/dub tags to polish and portuguese sites
- Updated links, fixed descs, removed dupes and reorganized stuff where needed
- Removed [Dark Machine](https://darkmachine.pl/), dead
- Removed [PolishSource](https://polishsource.cz/), priv tracker registration closed
- Removed [OpenClip](http://openclip.info/), low quality, no https, most links either redirect to smth paid or are dead
- Removed [filman.cc](https://filman.cc/), requires sign up even just to see the site
- Removed [K1n013f0ur's Pastebin](https://github.com/nbats/FMHYedit/blob/main/base64.md#k1n013f0urs-pastebin), deleted, should be removed from b64 page asw
- Removed [docer.pl](https://docer.pl/), all links seem to be dead
- Removed [Legendas Zone](https://www.legendas-zone.org), requires log in just to see the site
- Removed [MD.Saúde](https://www.mdsaude.com), [Tua Saúde](https://www.tuasaude.com), [Dieta Emagrece](https://dietaemagrece.com.br) and [Beleza e Saúde](https://belezaesaude.com) - Seems redundant to keep health news and blogs since no other section in non eng has those listed and theyre also easily googlable
- Removed [NONIOBlocker](https://github.com/DevTiagoCruz/NONIOBlocker), last update 2020 and all it does can be accomplished with general adblockers
- Removed [Plagiarisma](https://plagiarisma.net/pt/), unreliable
- Removed [Gerador de Nomes de Fantasia](https://www.nomesdefantasia.com), niche asf and easily googleable
- Removed [CatálogoApp](https://catalogoapp.mobi), paid media heck yeah catalogue
- Removed [TopFlix](https://topflix.tv), doesn't seem to have any videos?
- Removed [TV Aberta](https://apkpure.com/br/tv-aberta-lite/tv.aberta.lite), last update 2020