### PR TITLE
Add imginn as instagram frontend

### DIFF
--- a/AdblockVPNGuide.md
+++ b/AdblockVPNGuide.md
@@ -347,7 +347,7 @@
 * [Invidious Redirect](https://addons.mozilla.org/en-US/firefox/addon/hooktube-redirect/?src=search) - YouTube Frontend Redirect
 * [Nitter](https://nitter.net/) - Twitter Frontend / [Manage Feeds](https://github.com/pluja/Feetter)
 * [Photon](https://photon-reddit.com/) - Reddit Frontend
-* [Proxigram](https://codeberg.org/ThePenguinDev/Proxigram) - Instagram Frontend
+* [Proxigram](https://codeberg.org/ThePenguinDev/Proxigram) / [Imginn](https://imginn.com) - Instagram Frontends
 * [Proxitok](https://github.com/pablouser1/ProxiTok) or [TikNot](https://tiknot.netlify.app/) - Tiktok Frontends
 * [Tumlook](https://www.tumlook.com/) - Tumblr Frontend
 * [MikuInvidious](https://0xacab.org/johnxina/mikuinvidious) - BiliBili Frontend

--- a/single-page
+++ b/single-page
@@ -12593,7 +12593,7 @@ Use a **[Base64 Decoder](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage
 * [Invidious Redirect](https://addons.mozilla.org/en-US/firefox/addon/hooktube-redirect/?src=search) - YouTube Frontend Redirect
 * [Nitter](https://nitter.net/) - Twitter Frontend / [Manage Feeds](https://github.com/pluja/Feetter)
 * [Photon](https://photon-reddit.com/) - Reddit Frontend
-* [Proxigram](https://codeberg.org/ThePenguinDev/Proxigram) - Instagram Frontend
+* [Proxigram](https://codeberg.org/ThePenguinDev/Proxigram) / [Imginn](https://imginn.com) - Instagram Frontends
 * [Proxitok](https://github.com/pablouser1/ProxiTok) or [TikNot](https://tiknot.netlify.app/) - Tiktok Frontends
 * [Tumlook](https://www.tumlook.com/) - Tumblr Frontend
 * [MikuInvidious](https://0xacab.org/johnxina/mikuinvidious) - BiliBili Frontend


### PR DESCRIPTION
Imginn can be used to view and download ig posts without pesky logins.