### PR TITLE
Update STORAGE.md

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1797,21 +1797,19 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 ## Youtube Android Apps
 
-* ⭐ **[ReVanced](https://revanced.app)** / [Extended](https://github.com/inotia00/ReVanced_Extended), [ReVanced APKs](https://revanced-apks.pages.dev/) - Latest Revanced Apps / [Guide](https://redd.it/xlcny9)
-* ⭐ **[ReVanced Manager](https://github.com/revanced/revanced-manager)**
-* ⭐ **[ReVanced Extended](https://github.com/inotia00/revanced-patches/tree/revanced-extended)** / [Magisk Module](https://github.com/sixstrings/revanced-extended-magisk-module)
-* ⭐ **[ReVanced Magisk Module](https://github.com/j-hc/revanced-magisk-module)**
 * ⭐ **[LibreTube](https://github.com/libre-tube/LibreTube)**
 * ⭐ **[NewPipe](https://newpipe.net/)** / [Sponsorblock](https://github.com/polymorphicshade/NewPipe)
 * [Clipious](https://github.com/lamarios/clipious) - YouTube Frontend
-* [ReVanced Patcher](https://github.com/decipher3114/Revancify) or [ReX-patches](https://github.com/YT-Advanced/ReX-patches) - ReVanced Patches
 * [VueTube](https://github.com/VueTubeApp/VueTube)
 * [SkyTube](https://github.com/SkyTubeTeam/SkyTube)
 * [FreeTubeCordova](https://github.com/MarmadileManteater/FreeTubeCordova)
 
-### ReVanced App Builders
+### ReVanced
 
-[ReVanced Creator](https://github.com/XDream8/revanced-creator), [Docker-Py-ReVanced](https://github.com/nikhilbadyal/docker-py-revanced), [YT-AT](https://github.com/Zelooooo/AT-YT)
+* ⭐ **[ReVanced Manager](https://revanced.app/download)** - Patch YouTube and other APKs / [Guide](https://redd.it/xlcny9)
+* [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/)
+* [ReVanced Magisk Module](https://github.com/j-hc/revanced-magisk-module/releases) / [2](https://github.com/revanced-apks/build-apps/releases) / [3](https://github.com/sixstrings/revanced-extended-magisk-module) / [4](https://github.com/Zelooooo/AT-YT/releases) - Patched APKs including Magisk and Extended
+* [Revancify](https://github.com/decipher3114/Revancify), [ReVanced Creator](https://github.com/XDream8/revanced-creator) or [Docker-Py-ReVanced](https://github.com/nikhilbadyal/docker-py-revanced) - CLI Patchers
 
 ***
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1808,7 +1808,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 * ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) - Patch YouTube, Reddit, X and other Apps
 * [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases/latest) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Extended patches for YT, YTMusic and Reddit
-* [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated Patchers
+* [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases) or [AT-YT](https://github.com/Zelooooo/AT-YT/releases) - Automated Patchers
 * [revanced-cli](https://github.com/ReVanced/revanced-cli/), [Revancify](https://github.com/decipher3114/Revancify) or [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1809,7 +1809,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 * ⭐ **[ReVanced Manager](https://revanced.app/download)** - Patch YouTube and other APKs / [Guide](https://redd.it/xlcny9)
 * [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/)
 * [ReVanced Magisk Module Releases](https://github.com/j-hc/revanced-magisk-module/releases) / [2](https://github.com/revanced-apks/build-apps/releases) / [3](https://github.com/sixstrings/revanced-extended-magisk-module/releases) / [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases) / [AT-YT](https://github.com/Zelooooo/AT-YT/releases) - Automated patchers
-* [Revancify](https://github.com/decipher3114/Revancify), [ReVanced Creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
+* [Revancify](https://github.com/decipher3114/Revancify), [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1806,9 +1806,8 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 ### ReVanced
 
-* ⭐ **[ReVanced Manager](https://revanced.app/download)** - Patch YouTube and other APKs / [Guide](https://redd.it/xlcny9)
-* [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/)
-* [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases) / [revanced-apks](https://github.com/revanced-apks/build-apps/releases) / [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) / [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases) / [AT-YT](https://github.com/Zelooooo/AT-YT/releases) - Automated patchers
+* ⭐ **[ReVanced Manager](https://revanced.app/download)** or [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Patch YouTube, Reddit, X and other apps / [Guide](https://redd.it/xlcny9)
+* [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated patchers
 * [Revancify](https://github.com/decipher3114/Revancify), [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1808,7 +1808,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 * ⭐ **[ReVanced Manager](https://revanced.app/download)** - Patch YouTube and other APKs / [Guide](https://redd.it/xlcny9)
 * [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/)
-* [ReVanced Magisk Module Releases](https://github.com/j-hc/revanced-magisk-module/releases) / [2](https://github.com/revanced-apks/build-apps/releases) / [3](https://github.com/sixstrings/revanced-extended-magisk-module/releases) / [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases) / [AT-YT](https://github.com/Zelooooo/AT-YT/releases) - Patched APKs including Magisk and Extended
+* [ReVanced Magisk Module Releases](https://github.com/j-hc/revanced-magisk-module/releases) / [2](https://github.com/revanced-apks/build-apps/releases) / [3](https://github.com/sixstrings/revanced-extended-magisk-module/releases) / [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases) / [AT-YT](https://github.com/Zelooooo/AT-YT/releases) - Automated patchers
 * [Revancify](https://github.com/decipher3114/Revancify), [ReVanced Creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1806,7 +1806,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 ### ReVanced
 
-* ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) or [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Patch YouTube, Reddit, X and other Apps
+* ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) or [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases/latest) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Patch YouTube, Reddit, X and other Apps
 * [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated Patchers
 * [Revancify](https://github.com/decipher3114/Revancify) or [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1806,7 +1806,8 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 ### ReVanced
 
-* ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) or [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases/latest) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Patch YouTube, Reddit, X and other Apps
+* ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) - Patch YouTube, Reddit, X and other Apps
+* [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases/latest) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Extended patches for YT, YTMusic and Reddit
 * [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated Patchers
 * [Revancify](https://github.com/decipher3114/Revancify) or [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1806,7 +1806,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 ### ReVanced
 
-* ⭐ **[ReVanced Manager](https://revanced.app/download)** or [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Patch YouTube, Reddit, X and other apps / [Guide](https://redd.it/xlcny9)
+* ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) or [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Patch YouTube, Reddit, X and other apps
 * [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated patchers
 * [Revancify](https://github.com/decipher3114/Revancify), [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1809,7 +1809,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 * ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) - Patch YouTube, Reddit, X and other Apps
 * [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases/latest) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Extended patches for YT, YTMusic and Reddit
 * [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated Patchers
-* [Revancify](https://github.com/decipher3114/Revancify) or [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
+* [revanced-cli](https://github.com/ReVanced/revanced-cli/) [Revancify](https://github.com/decipher3114/Revancify) or [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1808,7 +1808,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 * ⭐ **[ReVanced Manager](https://revanced.app/download)** - Patch YouTube and other APKs / [Guide](https://redd.it/xlcny9)
 * [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/)
-* [ReVanced Magisk Module Releases](https://github.com/j-hc/revanced-magisk-module/releases) / [2](https://github.com/revanced-apks/build-apps/releases) / [3](https://github.com/sixstrings/revanced-extended-magisk-module/releases) / [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases) / [AT-YT](https://github.com/Zelooooo/AT-YT/releases) - Automated patchers
+* [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases) / [revanced-apks](https://github.com/revanced-apks/build-apps/releases) / [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) / [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases) / [AT-YT](https://github.com/Zelooooo/AT-YT/releases) - Automated patchers
 * [Revancify](https://github.com/decipher3114/Revancify), [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1809,7 +1809,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 * ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) - Patch YouTube, Reddit, X and other Apps
 * [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases/latest) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Extended patches for YT, YTMusic and Reddit
 * [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated Patchers
-* [revanced-cli](https://github.com/ReVanced/revanced-cli/) [Revancify](https://github.com/decipher3114/Revancify) or [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
+* [revanced-cli](https://github.com/ReVanced/revanced-cli/), [Revancify](https://github.com/decipher3114/Revancify) or [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1806,8 +1806,8 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 ### ReVanced
 
-* ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) or [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Patch YouTube, Reddit, X and other apps
-* [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated patchers
+* ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) or [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Patch YouTube, Reddit, X and other Apps
+* [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated Patchers
 * [Revancify](https://github.com/decipher3114/Revancify) or [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1808,7 +1808,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 * ⭐ **[ReVanced Manager](https://revanced.app/download)** - Patch YouTube and other APKs / [Guide](https://redd.it/xlcny9)
 * [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/)
-* [ReVanced Magisk Module](https://github.com/j-hc/revanced-magisk-module/releases) / [2](https://github.com/revanced-apks/build-apps/releases) / [3](https://github.com/sixstrings/revanced-extended-magisk-module) / [4](https://github.com/Zelooooo/AT-YT/releases) - Patched APKs including Magisk and Extended
+* [ReVanced Magisk Module Releases](https://github.com/j-hc/revanced-magisk-module/releases) / [2](https://github.com/revanced-apks/build-apps/releases) / [3](https://github.com/sixstrings/revanced-extended-magisk-module/releases) / [4](https://github.com/Zelooooo/AT-YT/releases) - Patched APKs including Magisk and Extended
 * [Revancify](https://github.com/decipher3114/Revancify), [ReVanced Creator](https://github.com/XDream8/revanced-creator) or [Docker-Py-ReVanced](https://github.com/nikhilbadyal/docker-py-revanced) - CLI Patchers
 
 ***

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1808,7 +1808,7 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 * ⭐ **[ReVanced Manager](https://revanced.app/download)** / [Guide](https://redd.it/xlcny9) or [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/) - Patch YouTube, Reddit, X and other apps
 * [revanced-magisk-module](https://github.com/j-hc/revanced-magisk-module/releases), [revanced-apks](https://github.com/revanced-apks/build-apps/releases), [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases), [AT-YT](https://github.com/Zelooooo/AT-YT/releases), [revanced-extended-magisk-module](https://github.com/sixstrings/revanced-extended-magisk-module/releases) - Automated patchers
-* [Revancify](https://github.com/decipher3114/Revancify), [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
+* [Revancify](https://github.com/decipher3114/Revancify) or [revanced-creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -1808,8 +1808,8 @@ http://24.13.229.188:8090/, http://104.131.175.196:8080/, http://70.88.180.169:8
 
 * ⭐ **[ReVanced Manager](https://revanced.app/download)** - Patch YouTube and other APKs / [Guide](https://redd.it/xlcny9)
 * [Revanced-Extended Manager](https://github.com/inotia00/revanced-manager/releases) / [Guide](https://www.reddit.com/r/revancedextended/comments/12vxggr/revanced_extended_guide_for_beginners/)
-* [ReVanced Magisk Module Releases](https://github.com/j-hc/revanced-magisk-module/releases) / [2](https://github.com/revanced-apks/build-apps/releases) / [3](https://github.com/sixstrings/revanced-extended-magisk-module/releases) / [4](https://github.com/Zelooooo/AT-YT/releases) - Patched APKs including Magisk and Extended
-* [Revancify](https://github.com/decipher3114/Revancify), [ReVanced Creator](https://github.com/XDream8/revanced-creator) or [Docker-Py-ReVanced](https://github.com/nikhilbadyal/docker-py-revanced) - CLI Patchers
+* [ReVanced Magisk Module Releases](https://github.com/j-hc/revanced-magisk-module/releases) / [2](https://github.com/revanced-apks/build-apps/releases) / [3](https://github.com/sixstrings/revanced-extended-magisk-module/releases) / [docker-py-revanced](https://github.com/nikhilbadyal/docker-py-revanced/releases) / [AT-YT](https://github.com/Zelooooo/AT-YT/releases) - Patched APKs including Magisk and Extended
+* [Revancify](https://github.com/decipher3114/Revancify), [ReVanced Creator](https://github.com/XDream8/revanced-creator) - CLI Patchers
 
 ***
 


### PR DESCRIPTION
Organize the revanced section which is messy with redundancies and disorganized:

- better descriptions to differentiate between the official manual patcher, automated patchers, and CLI patchers

- for automated patchers, I link the releases tab inside the repo, instead of just the repo. Because the releases tab is the point of it (to get the patched APKs)

- kept starred only the official ReVanced which requires patching manually but it probably has the better support from devs

- moved revanced to the revanced subsection. There is a bunch of links related to the project, and this way the subsection could be linked from reddit, twitter, instagram etc sections, since Revanced can patch all of those apps, not just YouTube

- deleted: 
  - https://github.com/revanced/revanced-manager redundant github link, already linked from the main Revanced Manager link which is https://revanced.app/download 
  - https://github.com/YT-Advanced/ReX-patches fork of ReVanced Extended that doesnt say the reason for forking so apparently its just a clone:  
  - https://revanced-apks.pages.dev/ this page only shows the latest release of Revanced APKs, so if that release does have an update for Youtube, but not for Reddit, you miss the Reddit APK which is up to date too. So instead I linked the release page in Github https://github.com/revanced-apks/build-apps/releases which shows all the releases. 
  - https://github.com/inotia00/ReVanced_Extended this repo is just for issues and requests, not the tool itself 
  - https://github.com/inotia00/revanced-patches/tree/revanced-extended this repo has the patches for revanced extended but its not a relevant link for users, it is for devs
  - https://github.com/sixstrings/revanced-extended-magisk-module/ this auto patcher has few stars and the most popular ones are already including the magisk module with revanced extended