### PR TITLE
Update Privacy Indexes

### DIFF
--- a/AdblockVPNGuide.md
+++ b/AdblockVPNGuide.md
@@ -200,14 +200,9 @@
 * ⭐ **[The New Oil](https://thenewoil.org/)** - Educational Guide
 * [Defensive Computing Checklist](https://defensivecomputingchecklist.com/) - Privacy Guide
 * [AvoidTheHack](https://avoidthehack.com/) - Privacy Blog
-
 * [Privacy Tools List](https://privacytoolslist.com/) - Privacy Tools
-* [Snopyta](https://snopyta.org/) - Privacy Tools
 * [Hostux](https://hostux.network/) - Privacy Tools
-* [Awesome Security](https://github.com/sbilly/awesome-security) - Privacy Tools
-* [Thunix](https://thunix.net/) - Privacy Tools
-* [Zero Data App](https://0data.app/) - Privacy Tools
-* [De-google-ify Internet](https://degooglisons-internet.org/en/alternatives/) - Privacy Tools
+
 * [Alternative Internet](https://github.com/redecentralize/alternative-internet) - Privacy Tools
 * [Awesome Windows Security](https://github.com/chryzsh/awesome-windows-security) - Privacy Tools
 * [Tzkuat Ressources](https://gitlab.com/tzkuat/Ressources) - Privacy Tools

--- a/AdblockVPNGuide.md
+++ b/AdblockVPNGuide.md
@@ -202,11 +202,8 @@
 * [AvoidTheHack](https://avoidthehack.com/) - Privacy Blog
 * [Privacy Tools List](https://privacytoolslist.com/) - Privacy Tools
 * [Hostux](https://hostux.network/) - Privacy Tools
+* [Alternative Internet](https://github.com/redecentralize/alternative-internet) - Collection of Decentralised Tools
 
-* [Alternative Internet](https://github.com/redecentralize/alternative-internet) - Privacy Tools
-* [Awesome Windows Security](https://github.com/chryzsh/awesome-windows-security) - Privacy Tools
-* [Tzkuat Ressources](https://gitlab.com/tzkuat/Ressources) - Privacy Tools
-* [awesome-humane-tech](https://codeberg.org/teaserbot-labs/delightful-humane-design) - Privacy Tools
 * [EncryptedList](https://encryptedlist.xyz/) - Privacy Tools
 * [ProductivePrivacy](https://productiveprivacy.com/) - Privacy Tools
 

--- a/AdblockVPNGuide.md
+++ b/AdblockVPNGuide.md
@@ -147,7 +147,6 @@
 * 🌐 **[Awesome Cryptography](https://github.com/sobolevn/awesome-cryptography)** - Cryptography Resources
 * 🌐 **[Awesome Vehicle Security](https://github.com/jaredthecoder/awesome-vehicle-security)** - Vehicle Security Resources
 * 🌐 **[Awesome Anti Censorship](https://github.com/danoctavian/awesome-anti-censorship)**, [Your Freedom](https://www.your-freedom.net/), [Geneva](https://geneva.cs.umd.edu/), [Cloak](https://github.com/cbeuw/Cloak) or [FreeBrowser](https://freebrowser.org/) / [Wiki](https://github.com/greatfire/wiki) - Anti-Censorship Resources
-* ↪️ **[Privacy Tools / Services](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_privacy_tools)**
 * ↪️ **[SMS Verification Sites](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_sms_verification_sites)**
 * ↪️ **[Password Data Breach Detection](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_password_data_breach_check)**
 * ↪️ **[File Encryption](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_file_encryption_tools)**
@@ -193,21 +192,15 @@
 
 ## ▷ Privacy Indexes
 
-* ⭐ **[Awesome Privacy](https://awesome-privacy.xyz/)** / [2](https://github.com/KevinColemanInc/awesome-privacy) / [3](https://github.com/pluja/awesome-privacy) - Privacy Tools
-* ⭐ **[Privacy Guides](https://www.privacyguides.org/)** - Privacy Tools
-* ⭐ **[Security List](https://security-list.js.org/)** - Privacy Tools
-* ⭐ **[The Hitchhiker’s Guide](https://anonymousplanet.org/)** / [2](https://raw.githubusercontent.com/Anon-Planet/thgtoa/master/guide.md) - Privacy Guide
-* ⭐ **[Surveillance Self-Defense](https://ssd.eff.org/)** - Privacy Guide
-* ⭐ **[The New Oil](https://thenewoil.org/index.html)** - Privacy Guide
+* ⭐ **[Awesome Privacy](https://awesome-privacy.xyz/)** / [2](https://github.com/pluja/awesome-privacy) - List of Privacy Software and Services
+* ⭐ **[Security List](https://security-list.js.org/)** - Collection of Tips and Resources for Protecting Privacy
+* ⭐ **[The Hitchhiker’s Guide](https://anonymousplanet.org/)** - Extensive Guide to Online Anonymity
+* ⭐ **[Privacy Guides](https://www.privacyguides.org/)** - Educational Guide
+* ⭐ **[Surveillance Self-Defense](https://ssd.eff.org/)** - Educational Guide
+* ⭐ **[The New Oil](https://thenewoil.org/)** - Educational Guide
 * [Defensive Computing Checklist](https://defensivecomputingchecklist.com/) - Privacy Guide
-* [Security In A Box](https://securityinabox.org/en/) - Privacy Guide
-* [AvoidTheHack](https://avoidthehack.com/) - Privacy Guide
-* [Eldritch Data](https://eldritchdata.neocities.org/) - Privacy Guide
-* [OWASP Cheatsheet](https://cheatsheetseries.owasp.org/index.html) - Privacy Guide
-* [madaidans-insecurities](https://madaidans-insecurities.github.io/) - Privacy Guide
-* [chef-koch](https://chef-koch.bearblog.dev/privacy-tools-list-by-chef-koch/) - Privacy Tools
-* [Privacy Respecting](https://github.com/nikitavoloboev/privacy-respecting) - Privacy Tools
-* [online-tools-for-the-pandemic](https://etherpad.wikimedia.org/p/online-tools-for-the-pandemic) - Privacy Tools
+* [AvoidTheHack](https://avoidthehack.com/) - Privacy Blog
+
 * [Privacy Tools List](https://privacytoolslist.com/) - Privacy Tools
 * [Snopyta](https://snopyta.org/) - Privacy Tools
 * [Hostux](https://hostux.network/) - Privacy Tools
@@ -218,7 +211,6 @@
 * [Alternative Internet](https://github.com/redecentralize/alternative-internet) - Privacy Tools
 * [Awesome Windows Security](https://github.com/chryzsh/awesome-windows-security) - Privacy Tools
 * [Tzkuat Ressources](https://gitlab.com/tzkuat/Ressources) - Privacy Tools
-* [PrivacySavvy](https://privacysavvy.com/) - Privacy Tools
 * [awesome-humane-tech](https://codeberg.org/teaserbot-labs/delightful-humane-design) - Privacy Tools
 * [EncryptedList](https://encryptedlist.xyz/) - Privacy Tools
 * [ProductivePrivacy](https://productiveprivacy.com/) - Privacy Tools

--- a/AdblockVPNGuide.md
+++ b/AdblockVPNGuide.md
@@ -192,8 +192,8 @@
 
 ## ▷ Privacy Indexes
 
-* ⭐ **[Awesome Privacy](https://awesome-privacy.xyz/)** / [2](https://github.com/pluja/awesome-privacy) - List of Privacy Software and Services
-* ⭐ **[Security List](https://security-list.js.org/)** - Collection of Tips and Resources for Protecting Privacy
+* ⭐ **[Awesome Privacy](https://awesome-privacy.xyz/)** / [2](https://github.com/pluja/awesome-privacy) - List of Privacy Software/Services
+* ⭐ **[Security List](https://security-list.js.org/)** - Collection of Tips/Resources for Protecting Privacy
 * ⭐ **[The Hitchhiker’s Guide](https://anonymousplanet.org/)** - Extensive Guide to Online Anonymity
 * ⭐ **[Privacy Guides](https://www.privacyguides.org/)** - Educational Guide
 * ⭐ **[Surveillance Self-Defense](https://ssd.eff.org/)** - Educational Guide
@@ -201,11 +201,10 @@
 * [Defensive Computing Checklist](https://defensivecomputingchecklist.com/) - Privacy Guide
 * [AvoidTheHack](https://avoidthehack.com/) - Privacy Blog
 * [Privacy Tools List](https://privacytoolslist.com/) - Privacy Tools
-* [Hostux](https://hostux.network/) - Privacy Tools
 * [Alternative Internet](https://github.com/redecentralize/alternative-internet) - Collection of Decentralised Tools
-
-* [EncryptedList](https://encryptedlist.xyz/) - Privacy Tools
-* [ProductivePrivacy](https://productiveprivacy.com/) - Privacy Tools
+* [EncryptedList](https://encryptedlist.xyz/) - List of Encrypted Services/Apps
+* [ProductivePrivacy](https://productiveprivacy.com/) - Privacy-Focused Productivity Apps 
+* [Hostux](https://hostux.network/) - Privacy Tools
 
 ***
 

--- a/DEVTools.md
+++ b/DEVTools.md
@@ -843,6 +843,7 @@
 * 🌐 **[Reverse Engineering Resources](https://github.com/wtsxDev/reverse-engineering)** - Reverse Engineering Resources
 * ↪️ **[Security / Hacking News](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/misc#wiki_.25B7_tech_news)**
 * ⭐ **[x64dbg](https://x64dbg.com/)** - Malware Reverse Engineering
+* [OWASP Cheatsheet](https://cheatsheetseries.owasp.org/) - Application Security Guide
 * [Open Source Security Software](https://open-source-security-software.net/) - Cybersecurity Software
 * [Advisory Database](https://github.com/github/advisory-database) or [Att&ck](https://attack.mitre.org/) - Cybersecurity Defense Databases
 * [SSuite](https://spidersuite.github.io/SSuite/) - Web Security App

--- a/DEVTools.md
+++ b/DEVTools.md
@@ -280,6 +280,7 @@
 * [Can't Unsee](https://cantunsee.space/) - UI Design Test
 * [UXTools](https://uxtools.co/) or [UXMovement](https://uxmovement.com/) - Learn UX Design
 * [SitePoint](https://www.sitepoint.com/) - UX Design Courses & Books
+* [delightful humane design](https://codeberg.org/teaserbot-labs/delightful-humane-design) - Humane Design Resources
 * [Laws of UX](https://lawsofux.com/) - Maxims / Principles for UI Designers
 * [Deceptive Patterns](https://www.deceptive.design/) - Deceptive User Experience Examples
 * [UI Coach](https://uicoach.io/) - UI Design Challenge Generator
@@ -843,8 +844,9 @@
 * 🌐 **[Reverse Engineering Resources](https://github.com/wtsxDev/reverse-engineering)** - Reverse Engineering Resources
 * ↪️ **[Security / Hacking News](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/misc#wiki_.25B7_tech_news)**
 * ⭐ **[x64dbg](https://x64dbg.com/)** - Malware Reverse Engineering
-* [OWASP Cheatsheet](https://cheatsheetseries.owasp.org/) - Application Security Guide
 * [Open Source Security Software](https://open-source-security-software.net/) - Cybersecurity Software
+* [OWASP Cheatsheet](https://cheatsheetseries.owasp.org/) - Application Security Guide
+* [Awesome Security](https://github.com/sbilly/awesome-security) - Collection of Security Resources
 * [Advisory Database](https://github.com/github/advisory-database) or [Att&ck](https://attack.mitre.org/) - Cybersecurity Defense Databases
 * [SSuite](https://spidersuite.github.io/SSuite/) - Web Security App
 * [osquery](https://github.com/osquery/osquery) or [Nmap](https://nmap.org/) - Security Monitors


### PR DESCRIPTION
Improved new Privacy Indexes section:
- Added/changed labels
- Removed outdated links
- Removed previous storage link
- Moved some entries to more suitable sections

Changelog:
```
Removed:
https://privacysavvy.com/ - recommends untrustworthy software and tools
https://raw.githubusercontent.com/Anon-Planet/thgtoa/master/guide.md - viewing the main site immediately offers better alternative ways to view the guide (browser, pdf, document, etc)
https://github.com/KevinColemanInc/awesome-privacy - last update: 2 years ago
https://securityinabox.org/en/ - outdated: 2021
https://eldritchdata.neocities.org/ - outdated + requires javascript disabled
https://madaidans-insecurities.github.io/ - outdated: 2021-2022
https://chef-koch.bearblog.dev/privacy-tools-list-by-chef-koch/ - old: 2021
https://github.com/nikitavoloboev/privacy-respecting - last commit: almost 2 years ago
https://etherpad.wikimedia.org/p/online-tools-for-the-pandemic - something happened?
https://degooglisons-internet.org/en/alternatives/ - no longer updated since 2019
https://github.com/chryzsh/awesome-windows-security - archived repo + no updates for 5 years
https://gitlab.com/tzkuat/Ressources - last commit: 3 years ago
https://snopyta.org/ - dead
https://thunix.net/ - not sure how useful it is, also in the wrong section
https://0data.app/ - not sure how useful it is

Moved:
https://cheatsheetseries.owasp.org/ - moved to Cybersecurity Tools
https://github.com/sbilly/awesome-security - moved to Cybersecurity Tools
https://codeberg.org/teaserbot-labs/delightful-humane-design - moved to UI / UX
```