### PR TITLE
Update STORAGE.md

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -190,16 +190,36 @@ http://104.131.175.196:8080/, http://70.88.180.169:8088/, http://207.237.122.161
 
 ## Color Palette Generators
 
-* ⭐ **[supercolorpalette](https://supercolorpalette.com/)**
-
-[SchemeColor](https://www.schemecolor.com/), [ColorSpace](https://mycolor.space/), [Adobe Color](https://color.adobe.com/), [0to255](https://0to255.com/), [Bootflat](https://bootflat.github.io/color-picker.html), [BrandColors](https://brandcolors.net/), [colorful gradients](https://colorfulgradients.tumblr.com/), [COLOURlovers](https://www.colourlovers.com/), [CoolHue](https://webkul.github.io/coolhue/), [Flat UI Colors 2](https://flatuicolors.com/), [Material UI](https://materialui.co/colors/), [Color Hunt](https://colorhunt.co/), [ColorsWall](https://colorswall.com/), [Pigment](https://pigment.shapefactory.co/), [Image to Color Palette Generator](https://www.patorjk.com/color-palette-generator/), [ColourCode](https://www.toptal.com/designers/colourcode/), [Colorscales](https://www.colorscales.com/en/start), [colors.lol](https://colors.lol/), [Color Palette Generator](https://www.degraeve.com/color-palette), [ColorBox](https://colorbox.io/), [Eva Design System](https://colors.eva.design/), [Scale](https://hihayk.github.io/scale/), [calcolor.co](https://calcolor.co/), [Color Lisa](https://colorlisa.com/), [Cohesive Colors](https://javier.xyz/cohesive-colors/), [Color Leap](https://colorleap.app/), [ColorHuddle](https://colorhuddle.co/), [Coolors](https://coolors.co/), [UI Colors](https://uicolors.app/create), [Randoma11y](https://randoma11y.com/), [Pywal](https://github.com/dylanaraps/pywal), [ColorKit](https://colorkit.co/color-palette-generator/), [Huemint](https://huemint.com/), [accessiblepalette](https://accessiblepalette.com/), [colorcolor](https://colorcolor.in/), [copypalette](https://copypalette.app/), [couleur.io](https://couleur.io/), [poolors](https://poolors.com/), [easycolour](https://easycolour.app/), [goodpalette](https://goodpalette.io/), [hue.tools](https://hue.tools/), [huey](https://huey.design/), [Schemist](https://schemist.fglt.fr/), [aicolors](https://aicolors.co/), [palettemaker](https://palettemaker.com/), [Branding Colors](https://brandingcolors.net/), [colorffy](https://colorffy.com/)
+* ⭐ **[supercolorpalette](https://supercolorpalette.com/)** - Color Palette Generator
+* [ColorSpace](https://mycolor.space/) - Generate Gradient Color Palettes
+* [ColorsWall](https://colorswall.com/) or [ColorKit](https://colorkit.co/color-palette-generator/) - Generate Random Color Palettes
+* [Color Palette Generator](https://www.degraeve.com/color-palette) or [Color Picker](https://imagecolorpicker.com/) - Generate Color Palettes from Images
+* [ColorKit](https://colorkit.io/) - Generate Color Palettes by Mixing 2 Colors
+* [Pigment](https://pigment.shapefactory.co/), [Eva Design System](https://colors.eva.design/), [Scale](https://hihayk.github.io/scale/), [copypalette](https://copypalette.app/) or [Huey](https://huey.design/) - Simple Color Palette Generators
+* [ColorBox](https://colorbox.io/), [hue.tools](https://hue.tools/), [Randoma11y](https://randoma11y.com/), [accessiblepalette](https://accessiblepalette.com/) or [colorcolor](https://colorcolor.in/) - Advanced Color Palette Generators
+* [goodpalette](https://goodpalette.io/), [Huemint](https://huemint.com/), [AI Colors](https://aicolors.co/) or [PaletteMaker](https://palettemaker.com/) - Generate UI Color Palettes
+* [couleur.io](https://couleur.io/) - CSS Color Palettes Generator
+* [UI Colors](https://uicolors.app/create) - Tailwind CSS Color Generator
+* [Poolors](https://poolors.com/) - Generate Most / Least Used Color Palettes
 
 ***
 
 ## Color Pickers
 
-[Colordot](https://color.hailpixel.com/), [Sorted CSS Colors](https://enes.in/sorted-colors/), [Chroma](https://chroma.spencerhamm.com/), [Adobe Color](https://color.adobe.com/explore), [Color Deck](https://color.obscuredetour.com/), [ColorKit](https://colorkit.io/), [Colorpicker](https://colorpicker.fr/), [Culrs](https://culrs.com/), [COLORWISE](https://colorwise.io/), [Geenes](https://geenes.app/welcome), [Image Color Picker](https://www.appypie.com/design/image-color-picker/), [Khroma](https://khroma.co/), [Just Color Picker](https://annystudio.com/software/colorpicker/), [Material Design Palette Generator](https://materialpalettes.com/), [Picular](https://picular.co/), [React Color](https://casesandberg.github.io/react-color/), [Leonardo](https://leonardocolor.io/), [Colors](https://clrs.cc/a11y/), [Color Picker](https://imagecolorpicker.com/), [cccolor](https://fffuel.co/cccolor/), [instant-eyedropper](https://github.com/miaupaw/instant-eyedropper), [ColorKit's Color Picker](https://colorkit.co/color-picker/), [epick](https://github.com/vv9k/epick)
-
+* 🌐 **[React Color](https://casesandberg.github.io/react-color/)** - Color Pickers Index
+* 🌐 **[BrandColors](https://brandcolors.net/)** - Brand Color Palettes Index
+* [Material UI](https://materialui.co/colors/), [Color Deck](https://color.obscuredetour.com/), [cccolor](https://fffuel.co/cccolor/), [Picular](https://picular.co/) or [ColorKit's Color Picker](https://colorkit.co/color-picker/) - Color Pickers
+* [Colorpicker](https://colorpicker.fr/), [Just Color Picker](https://annystudio.com/software/colorpicker/) or [epick](https://github.com/vv9k/epick) - Color Picker Desktop Apps
+* [Colorscales](https://www.colorscales.com/en/start) - Find Colors in Color Space
+* [ColourCode](https://www.toptal.com/designers/colourcode/) or [Colordot](https://color.hailpixel.com/) - Find Colors by Moving Mouse
+* [Geenes](https://geenes.app/welcome) or [Leonardo](https://leonardocolor.io/) - Find UI Color Palettes
+* [Sorted CSS Colors](https://enes.in/sorted-colors/) - Find Similar CSS Colors
+* [Color Hunt](https://colorhunt.co/), [COLOURlovers](https://www.colourlovers.com/), [SchemeColor](https://www.schemecolor.com/), [Culrs](https://culrs.com/) or [Colorffy](https://colorffy.com/) - Find Color Palettes
+* [Adobe Color](https://color.adobe.com/) - Find Color Palettes with Color Wheel
+* [Color Lisa](https://colorlisa.com/) - Find Art Based Color Palettes
+* [Color Leap](https://colorleap.app/) - Find Historical Color Palettes
+* [COLORWISE](https://colorwise.io/) - Find Color Palettes from Product Hunt Products
+  
 ***
 
 ## Collaboration Platforms


### PR DESCRIPTION
- Debloated and de-bulked Color Palette Generators and Color Pickers
- Reorganized a bunch of stuff in those categories since a lot of things were in the wrong place
- Color Palette Generators and Color Pickers can be moved out of storage now as their formatting matches regular sections
- Removed [0to255](https://0to255.com/), hard to navigate and nothing special
- Removed [Bootflat](https://bootflat.github.io/color-picker.html), not that good, not that many colors
- Removed [colorful gradients](https://colorfulgradients.tumblr.com/), can't copy colors from gradients, doesn't seem that useful
- Removed [CoolHue](https://webkul.github.io/coolhue/), not that many gradients and last update was 5 years ago, no longer maintained
- Removed [Image to Color Palette Generator](https://www.patorjk.com/color-palette-generator/), still in beta release, UI is basic html shit, doesn't seem maintained anymore and doesn't do anything better than the sites we already have
- Removed [colors.lol](https://colors.lol/), not that many palettes and most are shit, no longer maintained
- Removed [calcolor.co](https://calcolor.co/), not that good and requires signup for most stuff
- Removed [Cohesive Colors](https://javier.xyz/cohesive-colors/), not that useful
- Removed [ColorHuddle](https://colorhuddle.co/), just a site only equivalent of the microsoft power tools color picker, with not that many colors
- Removed [Coolors](https://coolors.co/), has ads and only up to 5 colors in the palette for free version, no better than the other sites and bitches too much about upgrading to pro
- Removed [Pywal](https://github.com/dylanaraps/pywal), last update 2 years ago
- Removed [easycolour](https://easycolour.app/), not that useful, just shows basic color info
- Removed [Schemist](https://schemist.fglt.fr/), not that good
- Removed [Branding Colors](https://brandingcolors.net/), not that useful
- Removed [Flat UI Colors 2](https://flatuicolors.com/), only 13 palettes and they're not that good
- Removed [Chroma](https://chroma.spencerhamm.com/), literally just an enlarged default color picker + epilepsy inducing site icon
- Removed [Image Color Picker](https://www.appypie.com/design/image-color-picker/), requires sign-up
- Removed [Material Design Palette Generator](https://materialpalettes.com/), not that useful, only shows basic info
- Removed [Khroma](https://khroma.co/), training is slow as shit and doesn't seem that useful
- Removed [Colors](https://clrs.cc/a11y/), doesn't seem useful
- Removed [instant-eyedropper](https://github.com/miaupaw/instant-eyedropper), unsure what it is, no releases and last update a year ago