### PR TITLE
Moved some categories out of storage, organized them, and added descs to links

### DIFF
--- a/GamingPiracyGuide.md
+++ b/GamingPiracyGuide.md
@@ -135,6 +135,15 @@
 
 ***
 
+## ▷ Game Soundtracks
+
+* [Khinsider](https://downloads.khinsider.com/) / [Downloader](https://github.com/obskyr/khinsider), [2](https://github.com/weespin/KhinsiderDownloader) - Game Soundtracks / MP3
+* [RetroTracks](https://retro.sx/) or [VGMPF](https://www.vgmpf.com/Wiki/index.php) - Retro Game Soundtracks / MP3
+* [VGMRips](https://vgmrips.net/packs/) or [Zophar's](https://www.zophar.net/music) - Retro Game Music Rips / VGM
+* [GameOST](https://gameost.net/) or [Roland SC-55](https://sc55.duke4.net/games.php) - Misc Game Soundtracks / MP3
+
+***
+
 ## ▷ [Linux Games](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/linux#wiki_.25B7_linux_gaming)
 
 ***
@@ -785,25 +794,33 @@
 
 # ► Game Mods
 
-* 🌐 **[FlingTrainer](https://flingtrainer.com/)** - Game Mods / Trainers
-* 🌐 **[Otis_Inf Camera Mods](https://redd.it/hvttbd)** - Game Camera Mods
-* ↪️ **[Game Mod Sites](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_game_mods)**
+* 🌐 **[FlingTrainer](https://flingtrainer.com/)** - Game Mods / Trainers Index
+* 🌐 **[Otis_Inf Camera Mods](https://redd.it/hvttbd)** - Game Camera Mods Index
 * ⭐ **[ChronoCrash](https://www.chronocrash.com/forum/)** - Game Modding Forum
+* ⭐ **[ModDB](https://moddb.com/)** or **[Nexus Mods](https://www.nexusmods.com/)** / [Manager](https://github.com/Nexus-Mods/Nexus-Mod-Manager) / [Redirect Skip](https://greasyfork.org/en/scripts/394039) - Misc Game Mods
+* ⭐ **[Modrinth](https://modrinth.com/)** / [Redirector](https://github.com/devBoi76/modrinthify) - Minecraft Mods
+* [ProAsm](http://www.proasm.com/) - Retro Game Mods
+* [Top Mods](https://www.top-mods.com/) - PC Game Mods
+* [ZagruzkaMods](https://zagruzkamods.com/) or [GameJunkie](https://www.gamejunkie.pro/) - Simulator Game Mods
+* [mod.io](https://www.mod.io/) - Cross Platform Game Mods Support
+* [WabbaJack](https://www.wabbajack.org/) / [Discord](https://discord.com/invite/wabbajack) - Automated Modlist Installer
+* [NextGenUpdate](https://www.nextgenupdate.com/), [ModWorkshop](https://modworkshop.net/), [GameFront](https://gamefront.com/), [Video Game Mods](https://videogamemods.com/) or [GameBanana](https://gamebanana.com/) - Misc Game Mods
+* [Silent's Blog](https://cookieplmonster.github.io/mods/index/) - Misc Game Mods / Patches
 * [HedgeModManager](https://github.com/thesupersonic16/HedgeModManager) - Sonic Game Mod Manager
 * [Hidden Fallout 4 Mods](https://rentry.co/89gads), [2](https://docs.google.com/document/d/1Im5Mg-l2btRsYVOjaJa0slrjDcXNvi41J5pHw_Zuwqw/edit?usp=sharing) - Fallout 4 Mods Removed from Nexus
 * [OpenFortress](https://openfortress.fun/) - Team Fortress 2 Mod
 * [TF2 Classic](https://tf2classic.com/) - Team Fortress 2 Classic Mod
 * [Rekt](https://discord.com/invite/HqjQFCp) - Black Ops 1 Mod Projects
-* [Plutonium](https://plutonium.pw/) - Black Ops 2 & MW3 Mod Project / [Discord](https://discord.gg/d95y8ah)
+* [Plutonium](https://plutonium.pw/) - Black Ops 2 / MW3 Mod Project / [Discord](https://discord.gg/d95y8ah)
 * [UGX Mods](https://www.ugx-mods.com/) - COD Zombies Mods / [Discord](https://discord.gg/g9S2nSp)
 * [Project Reality](https://www.realitymod.com/about) - BF2 & ARMA 2 Realism Mod
 * [BF3Reality](https://bf3reality.com/) - BF3 Realism Mod
-* [VeniceUnleashed](https://veniceunleashed.net/) (BF3) and [Warsaw-Revamped](https://warsaw-revamped.com/) (BF4) - Battlefield Mod Projects
+* [VeniceUnleashed - BF3](https://veniceunleashed.net/) or [Warsaw-Revamped - BF4](https://warsaw-revamped.com/) - Battlefield Mod Projects
 * [Open Carnage](https://opencarnage.net/) / [Discord](https://discord.com/invite/2pf3Yjb), [Reclaimers](https://reclaimers.net/) or [Halo Mods](https://discord.com/invite/WuurKwr) - Halo Modding Community
 * [Halo 3](https://store.steampowered.com/app/1695791/Halo_3_Mod_Tools__MCC/), [Halo 2](https://store.steampowered.com/app/1613450/Halo_2_Mod_Tools__MCC/) or [Halo CE](https://store.steampowered.com/app/1532190/Halo_CE_Mod_Tools__MCC/) - Halo Modding Tools
 * [H2Maps](https://www.h2maps.net/) - Custom Halo 2 Maps
 * [HaloMaps](http://www.halomaps.org/) - Halo CE Maps
-* [Flatout 2 Fan Patch](https://steamcommunity.com/sharedfiles/filedetails/?id=2414295888) - Patch for Flatout 2
+* [Flatout 2 Fan Patch](https://steamcommunity.com/sharedfiles/filedetails/?id=2414295888) - Flatout 2 Patches
 * [SWAT: Elite Force](https://www.moddb.com/mods/swat-elite-force) - Swat 4 Enhancement Mod
 * [Realm667](https://www.realm667.com/index.php/en/) - Doom Mods
 * [SLADE](https://slade.mancubus.net/) - Doom Modding Tool / [GitHub](https://github.com/sirjuddington/SLADE)
@@ -867,7 +884,6 @@
 
 # ► Gaming Tools
 
-* ↪️ **[Game Libraries / Launchers](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_game_libraries_.2F_launcher)**
 * ↪️ **[Media Posters / Covers](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_covers_.2F_posters)**
 * ⭐ **[Library of Codexes](https://libraryofcodexes.com/)** - Game Codex Library
 * ⭐ **[HowLongToBeat](https://howlongtobeat.com/)** - Find Average Game Lengths
@@ -932,6 +948,18 @@
 * [Arcade Controls](http://arcadecontrols.com/arcade.htm) - DIY Arcade Controls
 * [AltCtrls](https://altctrls.info/) - Custom Controller Crafting Resources
 * [How Denuvo Works](https://rentry.co/denuvo) or [Reverse Engineer Denuvo V4](https://drive.google.com/file/d/1CupcQMOyxbtNUGGSnq8xhIZIxhDzToFT/)
+
+***
+
+## ▷ Game Libraries / Launchers
+
+* ⭐ **[Playnite](https://playnite.link/)** / [Extensions](https://github.com/darklinkpower/PlayniteExtensionsCollection) / [Achievements](https://github.com/Lacro59/playnite-successstory-plugin) - Game Library / Launcher
+* ⭐ **[GoG Galaxy](https://www.gog.com/galaxy)** or **[Project GLD](https://github.com/Y0URD34TH/Project-GLD/)** - Game Libraries / Launchers
+* [Black Pearl Origin](https://github.com/BlackPearlOrigin/blackpearlorigin) / [Plugins](https://bpo-store.github.io/) - Cross Platform Game Library / Launcher
+* [Launchbox](https://www.launchbox-app.com/) - Retro / Console Game Library / Launcher
+* [GameHub](https://tkashkin.github.io/projects/gamehub/) or [Gnome Games](https://wiki.gnome.org/Apps/Games) - Linux Game Libraries / Launchers
+* [Arc](https://www.arcgames.com/en/about/client) - Gearbox Game Launcher / Library
+* [GameVault](https://gamevau.lt) - Self-hosted Gaming Platform
 
 ***
 

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -517,36 +517,6 @@ http://104.131.175.196:8080/, http://70.88.180.169:8088/, http://207.237.122.161
 
 ***
 
-## Game Libraries / Launcher
-
-* ⭐ **[Playnite](https://playnite.link/)** / [Extensions](https://github.com/darklinkpower/PlayniteExtensionsCollection) / [Achievements](https://github.com/Lacro59/playnite-successstory-plugin)
-* ⭐ **[GoG Galaxy](https://www.gog.com/galaxy)**
-* ⭐ **[Project GLD](https://github.com/Y0URD34TH/Project-GLD/)**
-* [Black Pearl Origin](https://github.com/BlackPearlOrigin/blackpearlorigin) / [Plugins](https://bpo-store.github.io/)
-
-[Launchbox](https://www.launchbox-app.com/), [GameHub](https://tkashkin.github.io/projects/gamehub/), [Arc](https://www.arcgames.com/en/about/client), [Gnome Games](https://wiki.gnome.org/Apps/Games), [GameVault](https://gamevau.lt)
-
-***
-
-## Game Mods
-
-* ⭐ **[ModDB](https://moddb.com/)**
-* ⭐ **[Nexus Mods](https://www.nexusmods.com/)** / [Manager](https://github.com/Nexus-Mods/Nexus-Mod-Manager) / [Redirect Skip](https://greasyfork.org/en/scripts/394039)
-* ⭐ **[Modrinth](https://modrinth.com/)** / [Redirector](https://github.com/devBoi76/modrinthify)
-* [ProAsm](http://www.proasm.com/) - Retro Game Mods
-
-[ZagruzkaMods](https://zagruzkamods.com/), [NextGenUpdate](https://www.nextgenupdate.com/), [ModWorkshop](https://modworkshop.net/), [Video Game Mods](https://videogamemods.com/), [Silent's Blog](https://cookieplmonster.github.io/mods/index/), [WabbaJack](https://www.wabbajack.org/) / [Discord](https://discord.com/invite/wabbajack), [GameFront](https://gamefront.com/), [GameJunkie](https://www.gamejunkie.pro/), [VIP Mods](https://www.vip-mods.com/), [top-mods.ru](https://top-mods.ru/), [vip-mods.ru](https://vip-mods.ru/), [Top Mods](https://www.top-mods.com/), [GameJunkie](https://gamejunkie.ru/), [mod.io](https://www.mod.io/), [GameBanana](https://gamebanana.com/)
-
-***
-
-## Game Soundtracks
-
-* [Khinsider](https://downloads.khinsider.com/) - [Downloader](https://github.com/obskyr/khinsider) / [2](https://github.com/weespin/KhinsiderDownloader)
-
-[Duke4 SC-55](https://sc55.duke4.net/games.php), [Project2612](https://project2612.org/index.php), [retro.sx](https://retro.sx/), [GameOST](https://gameost.net/), [VGMRips](https://vgmrips.net/packs/), [VGMPF](https://www.vgmpf.com/Wiki/index.php), [Zophar's](https://www.zophar.net/music)
-
-***
-
 ## GDrive File Sharing
 
 * https://filepress.click/
@@ -604,15 +574,6 @@ http://104.131.175.196:8080/, http://70.88.180.169:8088/, http://207.237.122.161
 
 ***
 
-## Image Colorization
-
-* [AnimeColorDeOldify](https://github.com/Dakini/AnimeColorDeOldify) - Anime Image Colorization
-* [style2paints](https://github.com/lllyasviel/style2paints) - Lineart Colorization
-
-[Petalica Paint](https://petalica.com/), [MyHeritage In Color](https://www.myheritage.com/incolor), [9Mail Restoration](https://9may.mail.ru/restoration/), [DeOldify](https://github.com/jantic/DeOldify), [playback](https://playback.fm/colorize-photo), [cutout](https://www.cutout.pro/photo-colorizer-black-and-white), [colorize.cc](https://colorize.cc/), [hotpot](https://hotpot.ai/colorize-picture), [Colorizer](https://deepai.org/machine-learning-model/colorizer), [imagecolorizer](https://imagecolorizer.com/)
-
-***
-
 ## Image Design Resources
 
 * ⭐ **[FreePreset](https://freepreset.net/)**
@@ -624,17 +585,6 @@ http://104.131.175.196:8080/, http://70.88.180.169:8088/, http://207.237.122.161
 ## Image Download Extensions
 
 [Download all Images](https://add0n.com/save-images.html), [Cute Save Button](https://github.com/Dezaimasu/cute-button), [DownAlbum](https://chromewebstore.google.com/detail/downalbum/cgjnhhjpfcdhbhlcmmjppicjmgfkppoken), [Save Images](https://github.com/belaviyo/save-images/), [svgexport](https://svgexport.io/), [svg-grabber](https://chromewebstore.google.com/detail/svg-grabber-get-all-the-s/ndakggdliegnegeclmfgodmgemdokdmg), [SVG Gobbler](https://github.com/rossmoody/svg-gobbler), [Image Picka](https://github.com/eight04/image-picka)
-
-***
-
-## Image to Text
-
-* ⭐ **[Capture2Text](https://capture2text.sourceforge.net/)**
-* ⭐ **[Text Grab](https://github.com/TheJoeFin/Text-Grab)**
-* ⭐ **[i2ocr](https://www.i2ocr.com/)** - Online OCR
-* ⭐ **[OCR.SPACE](https://ocr.space/)** - Online OCR
-
-[TextShot](https://github.com/ianzhao05/textshot), [OnlineOCR](https://onlineocr.org/), [NewOCR](https://www.newocr.com/), [Project Naptha](https://projectnaptha.com/), [Extract text from image](https://brandfolder.com/workbench/extract-text-from-image), [2ocr](https://2ocr.com/), [ImageToText](https://www.imagetotext.info/), [OnlineOCR](https://www.onlineocr.net/), [ImageScanOCR](https://github.com/ttop32/ImageScanOCR), [iblogbox OCR](https://imagetotext.iblogbox.com/), [Pomodoro](https://pomodoro.semlab.io/)
 
 ***
 
@@ -660,14 +610,14 @@ http://104.131.175.196:8080/, http://70.88.180.169:8088/, http://207.237.122.161
 
 ***
 
-## LibGen  Mirrors
+## LibGen Mirrors
 
 * https://libgen.rs/ - main
 * https://libgen.is/ - main
 * https://libgen.st/ - main
 * https://libgen.fun/ - fork by original dev
 * https://libgen.li/ - clone
-* https://libgen.gs/  - clone
+* https://libgen.gs/ - clone
 * https://libgen.vg/ - clone
 * https://libgen.pm/ - clone
 * https://rentry.co/fmhy-libgen - Differences between the mirrors
@@ -869,7 +819,7 @@ http://104.131.175.196:8080/, http://70.88.180.169:8088/, http://207.237.122.161
 * ⭐ **[AsINT_Collection](https://start.me/p/b5Aow7/asint_collection)**
 * [Osintracker](https://www.osintracker.com/) - OSINT Investigations Tracker
 
-[OSINT All](https://bin.disroot.org/?4e0f2f4f714641d1##GsU9NwvyyqUFmgLv2f5s6dtBZJYFARzwzdDMDk3tnkSD) / [2](https://start.me/p/0PwOGl/osint-all),  [OSINT Essentials](https://www.osintessentials.com/), [OSINT Collection](https://github.com/Ph055a/OSINT_Collection), [OSINT Sources](https://github.com/imuledx/OSINT_sources), [Investigator Tools](https://start.me/p/gyaOJz/investigator-tools), [geoint](https://start.me/p/W1kDAj/geoint), [OSINT Tools](https://start.me/p/wMdQMQ/tools), [Sector035](https://sector035.nl/), [Nixintel's OSINT](https://start.me/p/rx6Qj8/nixintel-s-osint-resource-list), [UK-OSINT](https://www.uk-osint.net/index.html), [OSINTGeek](https://osintgeek.de/tools), [Awesome-Telegram-OSINT](https://github.com/ItIsMeCall911/Awesome-Telegram-OSINT), [Hackers Arise OSINT](https://www.hackers-arise.com/osint), [osinttechniques](https://www.osinttechniques.com/osint-tools.html), [whatisosint](https://securitytrails.com/blog/what-is-osint-how-can-i-make-use-of-it), [osintdojo](https://www.osintdojo.com/resources/), [300m](https://300m.com/osint/), [einvestigator](https://www.einvestigator.com/open-source-intelligence-tools/), [researchclinic](https://researchclinic.net/), [toddington](https://www.toddington.com/resources/free-osint-resources-open-source-intelligence-search-tools-research-tools-online-investigation/), [reuser](https://rr.reuser.biz/), [booleanstrings](https://booleanstrings.com/tools/), [coreysdigs](https://www.coreysdigs.com/take-action/must-have-tools-for-digging-videos-podcasts/), [Bellingcat](https://docs.google.com/spreadsheets/d/18rtqh8EG2q1xBo2cLNyhIDuK9jrPGwYr9DI2UncoqJQ/), [cProject Owl](https://discord.gg/projectowl), [RedTeam-Resources](https://github.com/J0hnbX/RedTeam-Resources), [Awesome Forensics Tools](https://github.com/ivbeg/awesome-forensicstools), [OSINT Collection](https://rentry.co/o89dd), [cipher387](https://github.com/cipher387), [osint4all](https://start.me/p/L1rEYQ/osint4all), [OSINT Tools](https://pastebin.com/CJ9ExTn5), [osint](https://bin.disroot.org/?191675922ac1cbac##Dc6GZQUviM5mfQhoUsYhaBykx9RQAJkDp8yDAe8QqB1m), [asint_collection](https://bin.disroot.org/?5524218c228099ec##G6BxBj17tFtZhhGuYBfSRceFppigZyt8abJtqVceMgcN), [dig intel](https://start.me/p/ZME8nR/osint), [inteltechniques](https://inteltechniques.com/tools/Communities.html), [Social Media](https://start.me/p/4K0DXg/social-media), [midasearch](https://midasearch.org/), [osint-resources](https://start.me/p/1kAP0b/osint-resources), [Malfrat's Industries Map](https://map.malfrats.industries/), [OSHINT](https://ohshint.gitbook.io/oh-shint-its-a-blog/)
+[OSINT All](https://bin.disroot.org/?4e0f2f4f714641d1##GsU9NwvyyqUFmgLv2f5s6dtBZJYFARzwzdDMDk3tnkSD) / [2](https://start.me/p/0PwOGl/osint-all), [OSINT Essentials](https://www.osintessentials.com/), [OSINT Collection](https://github.com/Ph055a/OSINT_Collection), [OSINT Sources](https://github.com/imuledx/OSINT_sources), [Investigator Tools](https://start.me/p/gyaOJz/investigator-tools), [geoint](https://start.me/p/W1kDAj/geoint), [OSINT Tools](https://start.me/p/wMdQMQ/tools), [Sector035](https://sector035.nl/), [Nixintel's OSINT](https://start.me/p/rx6Qj8/nixintel-s-osint-resource-list), [UK-OSINT](https://www.uk-osint.net/index.html), [OSINTGeek](https://osintgeek.de/tools), [Awesome-Telegram-OSINT](https://github.com/ItIsMeCall911/Awesome-Telegram-OSINT), [Hackers Arise OSINT](https://www.hackers-arise.com/osint), [osinttechniques](https://www.osinttechniques.com/osint-tools.html), [whatisosint](https://securitytrails.com/blog/what-is-osint-how-can-i-make-use-of-it), [osintdojo](https://www.osintdojo.com/resources/), [300m](https://300m.com/osint/), [einvestigator](https://www.einvestigator.com/open-source-intelligence-tools/), [researchclinic](https://researchclinic.net/), [toddington](https://www.toddington.com/resources/free-osint-resources-open-source-intelligence-search-tools-research-tools-online-investigation/), [reuser](https://rr.reuser.biz/), [booleanstrings](https://booleanstrings.com/tools/), [coreysdigs](https://www.coreysdigs.com/take-action/must-have-tools-for-digging-videos-podcasts/), [Bellingcat](https://docs.google.com/spreadsheets/d/18rtqh8EG2q1xBo2cLNyhIDuK9jrPGwYr9DI2UncoqJQ/), [cProject Owl](https://discord.gg/projectowl), [RedTeam-Resources](https://github.com/J0hnbX/RedTeam-Resources), [Awesome Forensics Tools](https://github.com/ivbeg/awesome-forensicstools), [OSINT Collection](https://rentry.co/o89dd), [cipher387](https://github.com/cipher387), [osint4all](https://start.me/p/L1rEYQ/osint4all), [OSINT Tools](https://pastebin.com/CJ9ExTn5), [osint](https://bin.disroot.org/?191675922ac1cbac##Dc6GZQUviM5mfQhoUsYhaBykx9RQAJkDp8yDAe8QqB1m), [asint_collection](https://bin.disroot.org/?5524218c228099ec##G6BxBj17tFtZhhGuYBfSRceFppigZyt8abJtqVceMgcN), [dig intel](https://start.me/p/ZME8nR/osint), [inteltechniques](https://inteltechniques.com/tools/Communities.html), [Social Media](https://start.me/p/4K0DXg/social-media), [midasearch](https://midasearch.org/), [osint-resources](https://start.me/p/1kAP0b/osint-resources), [Malfrat's Industries Map](https://map.malfrats.industries/), [OSHINT](https://ohshint.gitbook.io/oh-shint-its-a-blog/)
 
 ***
 
@@ -1213,7 +1163,7 @@ http://104.131.175.196:8080/, http://70.88.180.169:8088/, http://207.237.122.161
 
 * ⭐ **[ggntw](https://ggntw.com/steam)**
 
-* [Steamworkshop.download](http://steamworkshop.download/), [steam-workshop-downloader.com](https://steam-workshop-downloader.com), [steamworkshopdownloader.ru](https://steamworkshopdownloader.ru), [steam-workshop-downloader](https://gramvio.com/steam-workshop-downloader/),  [Workshop Script](https://greasyfork.org/en/scripts/449046), [steamworkshopdownloader.ru](https://steamworkshopdownloader.ru/), [Workshop Downloader](https://4hub.app/workshop-downloader),
+* [Steamworkshop.download](http://steamworkshop.download/), [steam-workshop-downloader.com](https://steam-workshop-downloader.com), [steamworkshopdownloader.ru](https://steamworkshopdownloader.ru), [steam-workshop-downloader](https://gramvio.com/steam-workshop-downloader/), [Workshop Script](https://greasyfork.org/en/scripts/449046), [steamworkshopdownloader.ru](https://steamworkshopdownloader.ru/), [Workshop Downloader](https://4hub.app/workshop-downloader),
 
 ### Programs
 
@@ -1406,7 +1356,7 @@ http://104.131.175.196:8080/, http://70.88.180.169:8088/, http://207.237.122.161
 
 ## Waifu2x Tools
 
-[Guide](https://i.ibb.co/1MXJNPB/2eb637667b02.png) / [Colab](https://colab.research.google.com/drive/1RjyCk30cc24ez1-a1Qa3CP3g_yk9AJwq) / [GUI](https://github.com/YukihoAA/waifu2x_snowshell/releases), [2](https://github.com/nihui/waifu2x-ncnn-vulkan),  [3](https://github.com/AaronFeng753/Waifu2x-Extension-GUI) / [WebUI](https://unlimited.waifu2x.net/), [2](https://waifu2x.booru.pics/), [3](https://waifu2x.pro/), [4](https://waifu2x.udp.jp/), [5](https://waifu2x.org/), [6](https://waifuxl.com/)
+[Guide](https://i.ibb.co/1MXJNPB/2eb637667b02.png) / [Colab](https://colab.research.google.com/drive/1RjyCk30cc24ez1-a1Qa3CP3g_yk9AJwq) / [GUI](https://github.com/YukihoAA/waifu2x_snowshell/releases), [2](https://github.com/nihui/waifu2x-ncnn-vulkan), [3](https://github.com/AaronFeng753/Waifu2x-Extension-GUI) / [WebUI](https://unlimited.waifu2x.net/), [2](https://waifu2x.booru.pics/), [3](https://waifu2x.pro/), [4](https://waifu2x.udp.jp/), [5](https://waifu2x.org/), [6](https://waifuxl.com/)
 
 ***
 

--- a/Text-Tools.md
+++ b/Text-Tools.md
@@ -159,27 +159,6 @@
 * [MyReader](https://www.myreader.io/) - Text Summary
 * [Recast](https://www.letsrecast.ai/) - Text Summary
 
-
-***
-
-## ▷ Image to Text
-
-* ⭐ **[Capture2Text](https://capture2text.sourceforge.net/)**
-* [Text Grab](https://github.com/TheJoeFin/Text-Grab)
-* [TextShot](https://github.com/ianzhao05/textshot)
-* [OnlineOCR](https://onlineocr.org/)
-* [IMG2TXT](https://img2txt.com/)
-* [NewOCR](https://www.newocr.com/)
-* [OCR.SPACE](https://ocr.space/)
-* [Project Naptha](https://projectnaptha.com/)
-* [Extract text from image](https://brandfolder.com/workbench/extract-text-from-image)
-* [2ocr](https://2ocr.com/)
-* [i2ocr](https://www.i2ocr.com/)
-* [ImageToText](https://www.imagetotext.info/)
-* [OnlineOCR](https://www.onlineocr.net/)
-* [ImageScanOCR](https://github.com/ttop32/ImageScanOCR)
-* [iblogbox OCR](https://imagetotext.iblogbox.com/)
-
 ***
 
 ## ▷ Emoji Indexes

--- a/img-tools.md
+++ b/img-tools.md
@@ -92,7 +92,6 @@
 
 ## ▷ Upscale / Restore
 
-* ↪️ **[Colorize Images](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_image_colorization)** - Image Colorization Tools
 * ⭐ **[Waifu2x](https://github.com/nagadomi/waifu2x)** - Anime Image Upscaling / [Tools](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_waifu2x_tools)
 * ⭐ **[chaiNNer](https://github.com/chaiNNer-org/chaiNNer)** - Image Upscaling
 * ⭐ **[Upscale Wiki](https://upscale.wiki/wiki/Main_Page)** - Image Upscaling Wiki
@@ -125,6 +124,16 @@
 * [QualityScaler](https://github.com/Djdefrag/QualityScaler) - Image Upscaling
 * [GFPGAN](https://github.com/TencentARC/GFPGAN) - Face Upscaling
 * [resdet](https://github.com/0x09/resdet) - Detect if an Image is Upscaled
+
+***
+
+## ▷ Image Colorization
+
+* [AnimeColorDeOldify](https://github.com/Dakini/AnimeColorDeOldify) - Anime / Manga Image Colorization
+* [style2paints](https://github.com/lllyasviel/style2paints) - Lineart Colorization
+* [Petalica Paint](https://petalica.com/), [playback](https://playback.fm/colorize-photo), [cutout](https://www.cutout.pro/photo-colorizer-black-and-white), [hotpot](https://hotpot.ai/colorize-picture) or [Colorizer](https://deepai.org/machine-learning-model/colorizer) - Online Image Colorization
+* [DeOldify](https://github.com/jantic/DeOldify) - Image / Video Colorization
+* [imagecolorizer](https://imagecolorizer.com/) - Image Colorization / Restoration
 
 ***
 
@@ -473,7 +482,6 @@
 * 🌐 **[Creator Resources](https://www.newgrounds.com/wiki/creator-resources/)** - Art / Animation Resources
 * 🌐 **[Awesome Colab Notebooks](https://github.com/amrzv/awesome-colab-notebooks)** - Image Colab Resources
 * ↪️ **[Multi-Tool Image Sites](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_multi_image_tool_sites)**
-* ↪️ **[Image Text Extraction](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_image_to_text)**
 * ↪️ **[Color Scheme Tools](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/dev-tools#wiki_.25B7_color_schemes)** -  [Guide](https://i.ibb.co/cCRn3y1/5eb0a8de7dac.jpg)
 * ↪️ **[Color Pickers](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_color_pickers)**
 * ⭐ **[ImgOps](https://imgops.com/)** - Image Operations Meta-Tool
@@ -493,7 +501,6 @@
 * [behind!](https://github.com/kubuzetto/behind) - View Background Images
 * [Visual Center](https://javier.xyz/visual-center/) - Find the Visual Center of an Image
 * [Lithophane](https://3dp.rocks/lithophane) - Image to Lithophane Converter
-* [Handwriting-OCR](https://github.com/Breta01/handwriting-ocr) - Handwriting Image to Text
 * [WhatTheFont](https://www.myfonts.com/) - Find Font from Image
 * [RemoveWatermark](https://removewatermark.ai/), [Watermarkly](https://watermarkly.com/) or [Watermarkup](https://watermarkup.com/watermark.html) - Image Watermarking
 * [Watermark Remover Online](https://www.aiseesoft.com/watermark-remover-online/) or [Watermark Remover](https://www.watermarkremover.io/) - Watermark Removal
@@ -513,6 +520,19 @@
 * [3D Printed Mirror Array](https://github.com/bencbartlett/3D-printed-mirror-array) - Sunlight Pattern Mirror Array
 * [Make Photo Gallery](https://makephotogallery.net/) - Collage Creator
 * [The Slideshow](https://theslideshow.net/) - Google Image Slideshow
+
+***
+
+## ▷ Image to Text / OCR
+
+* ⭐ **[Capture2Text](https://capture2text.sourceforge.net/)** - OCR Desktop App
+* ⭐ **[Text Grab](https://github.com/TheJoeFin/Text-Grab)** - Minimal OCR Windows Tool
+* ⭐ **[i2ocr](https://www.i2ocr.com/)** or **[OCR.SPACE](https://ocr.space/)** - Online OCRs
+* [TextShot](https://github.com/ianzhao05/textshot) - Cross Platform OCR
+* [ImageScanOCR](https://github.com/ttop32/ImageScanOCR) - Windows OCR Tool
+* [Handwriting-OCR](https://github.com/Breta01/handwriting-ocr) - Handwriting OCR
+* [Project Naptha](https://projectnaptha.com/) - Automatic OCR while Browsing Images
+* [2OCR](https://2ocr.com/), [OnlineOCR](https://onlineocr.org/), [NewOCR](https://www.newocr.com/), [Extract Text from Image](https://brandfolder.com/workbench/extract-text-from-image), [ImageToText](https://www.imagetotext.info/) or [OnlineOCR](https://www.onlineocr.net/) - Online OCRs
 
 ***
 


### PR DESCRIPTION
- Moved Image to Text out of storage, added descs to links and renamed it Image to Text / OCR. I decided to include both name variations so both people who are familiar with what an OCR is and people who aren't can easily find what they're looking for
- Removed image to text from the TextTools category, doesn't feel like it belongs there at all but there can be a redirect to it somewhere on that page if deemed suitable
- Moved Image Colorization out of storage, added descs to links
- Moved Game Mods out of storage and placed it in the game mod category, added descs to links
- Moved Game Launchers / Libraries out of storage to gaming tools as a subcategory, added descs to links
- Moved Game Soundtracks out of storage to gaming download as a subcategory, added descs to links
- Removed some double spaces in storage
- Removed [iblogbox OCR](https://imagetotext.iblogbox.com/), requires login to see results
- Removed [Pomodoro](https://pomodoro.semlab.io/), terrible UI and seems broken
- Removed [MyHeritage In Color](https://www.myheritage.com/incolor), requires sign up
- Removed [9Mail Restoration](https://9may.mail.ru/restoration/), non eng and changing the language to english does nothing
- Removed [colorize.cc](https://colorize.cc/), free version has a obnoxious watermark
- Removed [VIP Mods](https://www.vip-mods.com/), last upload in 2022 and only had mods for 4 games, doesn't seem worth keeping
- Removed [top-mods.ru](https://top-mods.ru/) and [vip-mods.ru](https://vip-mods.ru/), non eng
- Removed [Project2612](https://project2612.org/index.php), dead