### PR TITLE
Cleaned up the 'Grammar Check' Section

### DIFF
--- a/Text-Tools.md
+++ b/Text-Tools.md
@@ -115,7 +115,7 @@
 * ⭐ **[Scribens](https://www.scribens.com/)**
 * [LanguageTool](https://languagetool.org/) - 9997 character limit
 * [Grammarly](https://www.grammarly.com/grammar-check)
-* [Scribbr](https://quillbot.com/grammar-check)
+* [Quillbot](https://quillbot.com/grammar-check)
 * [DeepL Write](https://www.deepl.com/write) - 2000 character limit; 3000 if you signup
 
 ***

--- a/Text-Tools.md
+++ b/Text-Tools.md
@@ -113,11 +113,9 @@
 ## ▷ Grammar Check
 
 * ⭐ **[Scribens](https://www.scribens.com/)**
-* [LanguageTool](https://languagetool.org/)
+* [LanguageTool](https://languagetool.org/) - 9997 character limit
 * [Grammarly](https://www.grammarly.com/grammar-check)
-* [Scribbr](https://www.scribbr.com/grammar-checker/)
-* [spellcheckplus](https://spellcheckplus.com/) - 2000 character limit
-* [GrammarCheck](https://www.grammarcheck.net/editor)
+* [Scribbr](https://quillbot.com/grammar-check)
 * [DeepL Write](https://www.deepl.com/write) - 2000 character limit; 3000 if you signup
 
 ***

--- a/Text-Tools.md
+++ b/Text-Tools.md
@@ -115,7 +115,7 @@
 * ⭐ **[Scribens](https://www.scribens.com/)**
 * [LanguageTool](https://languagetool.org/) - 9997 character limit
 * [Grammarly](https://www.grammarly.com/grammar-check)
-* [Quillbot](https://quillbot.com/grammar-check)
+* [QuillBot](https://quillbot.com/grammar-check)
 * [DeepL Write](https://www.deepl.com/write) - 2000 character limit; 3000 if you signup
 
 ***

--- a/Text-Tools.md
+++ b/Text-Tools.md
@@ -113,30 +113,12 @@
 ## ▷ Grammar Check
 
 * ⭐ **[Scribens](https://www.scribens.com/)**
-* ⭐ **[Jenni](https://jenni.ai/)**
-* [Wordtune](https://www.wordtune.com/)
-* [HemingwayApp](https://hemingwayapp.com/)
-* [Grammark](https://grammark.org/)
-* [SlickWrite](https://www.slickwrite.com/)
-* [Ginger Software](https://www.gingersoftware.com/grammarcheck)
 * [LanguageTool](https://languagetool.org/)
-* [Grammarly](https://www.grammarly.com/)
-* [Grammica](https://grammica.com/)
-* [Ludwig](https://ludwig.guru/)
-* [Scribbr](https://www.scribbr.com/)
-* [Writer](https://writer.com/)
-* [WordCounter](https://wordcounter.net/)
-* [RewriteTools](https://www.rewritertools.com/)
-* [TextGears](https://textgears.com/check-grammar-online)
-* [PolishMyWriting](https://www.polishmywriting.com/)
-* [Reverso Spellcheck](https://www.reverso.net/spell-checker/english-spelling-grammar/)
-* [spellcheckplus](https://spellcheckplus.com/)
-* [GrammarCheck](https://www.grammarcheck.net/)
-* [ContentRow](https://www.contentrow.com/)
-* [BibMe](https://www.bibme.org/)
-* [DeepL Write](https://www.deepl.com/write)
-* [PaperPal](https://paperpal.com/)
-* [Expresso](https://www.expresso-app.org/)
+* [Grammarly](https://www.grammarly.com/grammar-check)
+* [Scribbr](https://www.scribbr.com/grammar-checker/)
+* [spellcheckplus](https://spellcheckplus.com/) - 2000 character limit
+* [GrammarCheck](https://www.grammarcheck.net/editor)
+* [DeepL Write](https://www.deepl.com/write) - 2000 character limit; 3000 if you signup
 
 ***
 

--- a/Text-Tools.md
+++ b/Text-Tools.md
@@ -115,6 +115,7 @@
 * ⭐ **[Scribens](https://www.scribens.com/)**
 * [LanguageTool](https://languagetool.org/) - 9997 character limit
 * [Grammarly](https://www.grammarly.com/grammar-check)
+* [ProWritingAid](https://prowritingaid.com/grammar-checker)
 * [QuillBot](https://quillbot.com/grammar-check)
 * [DeepL Write](https://www.deepl.com/write) - 2000 character limit; 3000 if you signup
 


### PR DESCRIPTION
Removed [Jenni](https://jenni.ai/) Free plan only allows 200 AI words. Doesn't really help with grammar at all, it just helps with writing (which you only get 200 words). No spell check, no punctuation checker. Oh.. and you need an account. Has a lot of bloat features that don't really serve a purpose. Pricing is horrible if you want to get more AI words. ChatGPT would be a better choice.

Removed [Wordtune](https://www.wordtune.com/) free plan too limited.

Removed [HemingwayApp](https://hemingwayapp.com/) Important things are locked behind their 'Hemingway AI' which has a free plan... But their free plan doesn't fix your grammar.

Removed [SlickWrite](https://www.slickwrite.com/) Doesn't fix spelling mistakes or punctuation.

Removed [Ginger Software](https://www.gingersoftware.com/grammarcheck) 450 letter limit. I just used the website "Check Text" and not the MS Office plugin, so no clue how that works. Maybe if someone can try that and it's good it may be re-added.

Updated Grammarly URL to the grammar checker that DOESN'T require an account.

Removed [Grammica](https://grammica.com/) Couldn't get the grammar check to work (or at least didn't fix any of the grammar mistakes that I gave it.) Spinbot has 1000 word limit. Spell check didn't seem to fix spelling errors.

Removed [Ludwig](https://ludwig.guru/) Free plan is too limited. Requires an account.

Updated Sribbr URL to the grammar checker that DOESN'T require an account.

Removed [WordCounter](https://wordcounter.net/) It uses Grammarly for the Grammar & spell check. All it does without logging into Grammarly is count words...

Removed [RewriteTools](https://www.rewritertools.com/) Grammar checker requires an account, once you make an account and try the grammar checker it tells me the word limit is exceeded but doesn't tell me how many words I can do.

Removed [TextGears](https://textgears.com/check-grammar-online) 500 letter limit.

Removed [PolishMyWriting](https://www.polishmywriting.com/) 404 error when click "Check Writing."

Removed [Reverso Spellcheck](https://www.reverso.net/spell-checker/english-spelling-grammar/) 360 letter limit.

Updated Grammercheck URL to the editor.

[ContentRow](https://www.contentrow.com/) requires account, bad privacy policy, 3000 word/month limit.

Removed [BibMe](https://www.bibme.org/) horrible grammar check.

Removed [PaperPal](https://paperpal.com/) free plan too limited.

Removed [Expresso](https://www.expresso-app.org/) doesn't fix spelling or punctuation. 

I wasn't sure about [Writer](https://writer.com/) but I took it out since nbats said no paid stuff. This is a really good one on the list but its only free for 14 days then you have to pay, or make another account. Soooo didn't know what to do with this one. I'd like to see it stay but I don't think that aligns with FMHY's mission.

Hopefully I did this right, I'm willing to change / add things back if you want.