### PR TITLE
Update STORAGE.md

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -533,21 +533,22 @@ http://104.131.175.196:8080/, http://70.88.180.169:8088/, http://207.237.122.161
 
 ## Icon Download Sites
 
-* 🌐 **[Awesome Icons](https://github.com/notlmn/awesome-icons)** or **[Awesome Stock Resources](https://github.com/neutraltone/awesome-stock-resources#icons)** - SVG / PNG / Font Icons Index
+* 🌐 **[Awesome Icons](https://github.com/notlmn/awesome-icons)**, **[Awesome Stock Resources](https://github.com/neutraltone/awesome-stock-resources#icons)** or **[Free Icons](https://www.iconshock.com/freeicons/)** - Icon Indexes
 * ↪️ **[Icon Drives](https://rentry.co/FMHYBase64#icon-drives)** - Icon Drives 
-* ⭐ **[SVG Repo](https://www.svgrepo.com/)** - SVG Vectors / Icons
-* ⭐ **[icons8](https://icons8.com/icons)**, [Feather Icons](https://feathericons.com/), [Flaticon](https://www.flaticon.com/), [Devicon](https://devicon.dev/) or [Glyphs](https://glyphs.fyi/) - Customizable Dev Icons
+* ⭐ **[SVG Repo](https://www.svgrepo.com/)** - Customizable SVG Icons / Vectors
+* ⭐ **[icons8](https://icons8.com/icons)**, [Flaticon](https://www.flaticon.com/), [Devicon](https://devicon.dev/) or [Glyphs](https://glyphs.fyi/) - Customizable Icons
 * ⭐ **[Alphacoders Avatars](https://avatars.alphacoders.com/)** - PFP Icons / GIFs
-* [IconPacks](https://www.iconpacks.net/), [ant.design](https://ant.design/components/icon/), [teenyicons](https://teenyicons.com/), [iconify](https://iconify.design/), [svgmix](https://svgmix.com/), [Iconbuddy](https://iconbuddy.app/) - SVG / PNG Icons
-* [IconArchive](https://iconarchive.com/), [IconDuck](https://iconduck.com/), [icon icons](https://icon-icons.com/), [icons-for-free](https://icons-for-free.com/), [Streamline](https://www.streamlinehq.com/), [dryicons](https://dryicons.com/), [icones](https://icones.js.org/) - Icon Packs
-* [flexiple](https://flexiple.com/illustrations/) or [IconHunt](https://www.iconhunt.site/) - Vector Icons
-* [VecteezyDownloader](https://vecteezy-downloader.beatsnoop.com/) - Vecteezy Downloader
-* [RealFaviconGenerator](https://realfavicongenerator.net/) - Favicon Generator
+* [IconArchive](https://iconarchive.com/), [IconDuck](https://iconduck.com/), [icon icons](https://icon-icons.com/), [Icons-For-Free](https://icons-for-free.com/), [Streamline](https://www.streamlinehq.com/), [Dryicons](https://dryicons.com/) or [Icones](https://icones.js.org/) - Icon Packs
+* [IconPacks](https://www.iconpacks.net/), [svgmix](https://svgmix.com/), [Iconbuddy](https://iconbuddy.app/), [Noun Project](https://thenounproject.com/) or [cappuccicons](https://cappuccicons.com/) - SVG / PNG Icons
+* [Icofont](https://icofont.com/icons), [Polaris](https://polaris.shopify.com/icons), [Phosphor Icons](https://phosphoricons.com/), [Ant Design](https://ant.design/components/icon/) or [Orion](https://www.orioniconlibrary.com/) - SVG Icons
 * [GrommetIcons](https://icons.grommet.io/) - SVG Icons for React
+* [CaptainIconWeb](https://mariodelvalle.github.io/CaptainIconWeb/), [Iconify](https://iconify.design/) or [IconHunt](https://www.iconhunt.site/) - Vector Icons
 * [StyledIcons](https://styled-icons.dev/) - Import Icons as Styled Components
+* [Teenyicons](https://teenyicons.com/) - Minimal 1px Icons
+* [awsicons](https://awsicons.dev/) - AWS Icons
 * [Game-icons](https://game-icons.net/) - Game Icons
-
-[HealthIcons](https://healthicons.org/), [Icofont](https://icofont.com/icons), [Polaris](https://polaris.shopify.com/icons), [Phosphor Icons](https://phosphoricons.com/), [cappuccicons](https://cappuccicons.com/), [awsicons](https://awsicons.dev/), [iconshock](https://www.iconshock.com/freeicons/), [CaptainIconWeb](https://mariodelvalle.github.io/CaptainIconWeb/), [thenounproject](https://thenounproject.com/), [Orion](https://www.orioniconlibrary.com/), [shape.so](https://shape.so/)
+* [HealthIcons](https://healthicons.org/) - Medical Icons
+* [RealFaviconGenerator](https://realfavicongenerator.net/) - Favicon Generator
 
 ***
 


### PR DESCRIPTION
- Organized Icon Download Sites, they can now be moved out of storage
- Removed [flexiple](https://flexiple.com/illustrations/), illustrations not icons
- Removed [Feather Icons](https://feathericons.com/), already mentioned in one of the indexes and nothing unique
- Removed [VecteezyDownloader](https://vecteezy-downloader.beatsnoop.com/), doesn't really belong here since vecteezy is mostly used for images