### PR TITLE
Update VideoPiracyGuide.md

### DIFF
--- a/VideoPiracyGuide.md
+++ b/VideoPiracyGuide.md
@@ -475,7 +475,8 @@
 * [CricHD](https://v4.crichd.tv/) - Sports
 * [UFCKhabib](https://sportsurge.stream/) - Sports
 * [TotalSportek](https://totalsportek.pro/), [2](https://www.totalsportek.to/) - Sports
-* [Rojadirecta](http://www.rojadirecta.eu/) - Sports / [Forum](http://forum.rojadirecta.es/)
+* [Rojadirecta.eu](http://www.rojadirecta.eu/) - Sports / [Forum](http://forum.rojadirecta.es/)
+* [Rojadirecta.tube](https://www.rojadirecta.tube/) - Sports
 * [BoxingStreams100](https://boxings.boxingstreams100.com/) - Boxing
 * [Boxing Stream](https://boxingstream.ai/) - Boxing
 * [/r/WWEstreams/](https://www.reddit.com/r/WWEstreams/) - Wrestling

--- a/VideoPiracyGuide.md
+++ b/VideoPiracyGuide.md
@@ -475,8 +475,7 @@
 * [CricHD](https://v4.crichd.tv/) - Sports
 * [UFCKhabib](https://sportsurge.stream/) - Sports
 * [TotalSportek](https://totalsportek.pro/), [2](https://www.totalsportek.to/) - Sports
-* [Rojadirecta.eu](http://www.rojadirecta.eu/) - Sports / [Forum](http://forum.rojadirecta.es/)
-* [Rojadirecta.tube](https://www.rojadirecta.tube/) - Sports
+* [Rojadirecta](http://www.rojadirecta.eu/) - Sports / [Forum](http://forum.rojadirecta.es/)
 * [BoxingStreams100](https://boxings.boxingstreams100.com/) - Boxing
 * [Boxing Stream](https://boxingstream.ai/) - Boxing
 * [/r/WWEstreams/](https://www.reddit.com/r/WWEstreams/) - Wrestling

--- a/VideoPiracyGuide.md
+++ b/VideoPiracyGuide.md
@@ -475,7 +475,7 @@
 * [CricHD](https://v4.crichd.tv/) - Sports
 * [UFCKhabib](https://sportsurge.stream/) - Sports
 * [TotalSportek](https://totalsportek.pro/), [2](https://www.totalsportek.to/) - Sports
-* [Rojadirecta](https://www.rojadirecta.tube/) - Sports / [Forum](http://forum.rojadirecta.es/)
+* [Rojadirecta](http://www.rojadirecta.eu/) - Sports / [Forum](http://forum.rojadirecta.es/)
 * [BoxingStreams100](https://boxings.boxingstreams100.com/) - Boxing
 * [Boxing Stream](https://boxingstream.ai/) - Boxing
 * [/r/WWEstreams/](https://www.reddit.com/r/WWEstreams/) - Wrestling


### PR DESCRIPTION
switch to the true original URL for "rojadirecta" http://www.rojadirecta.eu/

its the one linked from that forum http://forum.rojadirecta.es/ and from twitter https://nitter.net/Rojadirecta, and it blocks access from IP addresses from Spain