### PR TITLE
Update

### DIFF
--- a/File-Tools.md
+++ b/File-Tools.md
@@ -41,8 +41,8 @@
 
 ## ▷ Download Managers
 
+* ⭐ **[JDownloader](https://jdownloader.org/jdownloader2)** - Download Manager / [Debloat](https://rentry.org/jdownloader2) / [Dark Theme](https://redd.it/q3xrgj) / [Dracula Theme](https://draculatheme.com/jdownloader2) / [Captcha Solver](https://github.com/cracker0dks/CaptchaSolver)
 * ⭐ **[IDM](https://www.internetdownloadmanager.com/)** - Download Manager / [Activation](https://massgrave.dev/idm-activation-script.html)
-* ⭐ **[JDownloader](https://jdownloader.org/jdownloader2)** - Download Manager / [Dark Theme](https://redd.it/q3xrgj) / [Dracula Theme](https://draculatheme.com/jdownloader2) / [Debloat](https://rentry.org/jdownloader2) / [Captcha Solver](https://github.com/cracker0dks/CaptchaSolver)
 * ⭐ **[XDM](https://xtremedownloadmanager.com/)** - Download Manager / [GitHub](https://github.com/subhra74/xdm) 
 * [Motrix](https://www.motrix.app/) - Download Manager / [Web Extensions](https://github.com/gautamkrishnar/motrix-webextension/) / [GitHub](https://github.com/agalwood/Motrix)
 * [Mipony](https://www.mipony.net/) - Download Manager

--- a/VideoPiracyGuide.md
+++ b/VideoPiracyGuide.md
@@ -630,7 +630,7 @@
 
 * ⭐ **[moo](https://rentry.co/FMHYBase64#moo)** - Movies / TV
 * ⭐ **[Media](https://rentry.co/FMHYBase64#media)** - Movies / TV / Anime
-* ⭐ **[Vadapav](https://rentry.co/FMHYBase64#vadapav)** - Movies / TV / Anime / [Discord](https://discord.gg/QtAwpdFKU5)
+* ⭐ **[Vadapav](https://rentry.co/FMHYBase64#vadapav)** - Movies / TV / Anime /
 * [188.165.227.112](https://rentry.co/FMHYBase64#188165227112) - Movies / TV
 * [Extreme Mirror](https://rentry.co/FMHYBase64#extreme-mirror) - Movies / TV / Anime
 * [r/moviegod](https://rentry.co/FMHYBase64#rmoviegod) - Movies


### PR DESCRIPTION
- Removed discord link to Dhokla, project is discontinued and Vadapav is now the main focus. I left out the new discord as its linked on their website, so probably best to not bring too much attention to it.
- Moved JDownloader to the top. it has some features still not available in IDM, such as bulk-install from multiple links, and things like the RD plugin for easy integration makes it way more convenient.
- Also moved the debloat link at the front, maybe the captcha solver can also go next to it?