### PR TITLE
Update Non-English.md

### DIFF
--- a/Non-English.md
+++ b/Non-English.md
@@ -1386,6 +1386,7 @@
 * [Flipax2](https://flipax2.me/) - Video / Audio / Reading / Castilian
 * [Fiuxy2](https://fiuxy2.co/) - Video / Audio / Reading / NSFW / [Bypass](https://greasyfork.org/en/scripts/477591)
 * [La Taberna Del Cangrejo](http://www.latabernadelcangrejo.eu/) - Video / Audio
+* [PelisEnHD](https://pelisenhd.org/) - Movies / TV / Anime / 4K / Latino / Castilian / [Partial Bypass](https://greasyfork.org/en/scripts/486337)
 * [Descargandoxmega](https://www.descargandoxmega.com/) - Movies / TV / Animation / Latino / Castilian
 * [SomosMovies](https://somosmovies.com/) - Movies / TV
 * [VerePeliculas](https://wvw.verepeliculas.com/) - Movies / TV / Latino


### PR DESCRIPTION
I PRd to removed pelisenhd.org but after looking it in detail, its the only or one of the few sites that have **4K** releases in Spanish, with 1fichier links still up. Their link shortener is annoying and now my script only bypasses it partially. I thought this was bad, until seeing they have those unique 4k releases