### PR TITLE
Update GamingPiracyGuide.md

### DIFF
--- a/GamingPiracyGuide.md
+++ b/GamingPiracyGuide.md
@@ -185,9 +185,6 @@
 * [RPCS3 Setup Guide](https://docs.google.com/document/d/1gdjNab-CtVS97jH2diPPP5tCrpBeof9-qPIRRB9-BrU/edit) - RPCS3 Emulator Setup Guide
 * [PCSX-Redux](https://github.com/grumpycoders/pcsx-redux) - PSCX Development Emulator
 * [Modernized PCSX2 Settings](https://mega.nz/folder/WdNAlY5Z#K6PmrQFyDm2k7BEV8KoAmg) - Premade PCSX2 Settings
-* [TeknoParrot](https://teknoparrot.com/) - Modern Arcade Client
-* [FightCade](https://www.fightcade.com/), [OpenBOR](https://github.com/DCurrent/openbor) or [Mugen](https://mugenarchive.com/forums/downloads.php?do=cat&id=39-mugen-builds) - Fighting Game Emulators
-* [ScummVM](https://www.scummvm.org/) - Classic Graphical Adventure Game Engines
 * [Mudlet](https://www.mudlet.org/) - Text Adventure Game Platform
 * [webnofrendo](https://zardam.github.io/webnofrendo/) - NES Numworks Emulator
 * [RetroAchievements](https://retroachievements.org/) - Achievements for Emulators


### PR DESCRIPTION
Removed (already on emugen wiki):
- https://teknoparrot.com/ -> https://emulation.gametechwiki.com/index.php/TeknoParrot
- https://www.fightcade.com/ -> https://emulation.gametechwiki.com/index.php/Fightcade
- https://github.com/DCurrent/openbor -> https://emulation.gametechwiki.com/index.php/OpenBOR
- https://mugenarchive.com/forums/downloads.php?do=cat&id=39-mugen-builds -> https://emulation.gametechwiki.com/index.php/Mugen
- https://www.scummvm.org/ -> https://emulation.gametechwiki.com/index.php/ScummVM