### PR TITLE
Update GamingPiracyGuide.md

### DIFF
--- a/GamingPiracyGuide.md
+++ b/GamingPiracyGuide.md
@@ -70,43 +70,29 @@
 * 🌐 **[Awesome Game Remakes](https://github.com/radek-sprta/awesome-game-remakes)** or [Game Clones](https://osgameclones.com/) - Open-Source Remakes
 * 🌐 **[Awesome Terminal Games](https://ligurio.github.io/awesome-ttygames/)** - ASCII Terminal Games
 * ↪️ **[DOS](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_dos_games)** / **[MSX Games](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_msx_games)**
-* ⭐ **[My Abandonware](https://www.myabandonware.com/)** - Abandonware
-* ⭐ **[AbandonwareGames](https://abandonwaregames.net/)** - Abandonware
-* ⭐ **[ZDoom](https://www.zdoom.org/downloads)** - Doom Source Port
-* ⭐ **[ZDaemon](https://www.zdaemon.org/)**, **[Doomseeker](https://doomseeker.drdteam.org/)**, [oDamex](https://odamex.net/), [DoomUtils](http://doomutils.ucoz.com/) or [Zandronum](https://zandronum.com/) - Online Multiplayer Doom
-* ⭐ **[CsWarzOnE](https://cswarzone.com/)** - Counter-Strike Downloads
+* ⭐ **[My Abandonware](https://www.myabandonware.com/)** or **[AbandonwareGames](https://abandonwaregames.net/)** - Abandonware
 * ⭐ **[OpenRCT2](https://openrct2.io/)** - Open-Source RollerCoaster Tycoon 2
-* [PCGameAbandonware](https://www.pcgamesabandonware.com/) - Abandonware
-* [Flashtro](https://flashtro.com/) - Abandonware
-* [Zombs-Lair](https://www.zombs-lair.com/) - Abandonware
-* [Old-Games.com](https://www.old-games.com/) - Abandonware
-* [VETUSWARE](https://vetusware.com/category/Games/?cat=7) - Abandonware
+* [PCGameAbandonware](https://www.pcgamesabandonware.com/), [Flashtro](https://flashtro.com/), [Zombs-Lair](https://www.zombs-lair.com/), [Old-Games.com](https://www.old-games.com/) or [VETUSWARE](https://vetusware.com/category/Games/) - Abandonware
 * [GamesNostalgia](https://gamesnostalgia.com/), [lemon64](https://www.lemon64.com/), [whdload](https://www.whdload.de/), [lemonamiga](https://www.lemonamiga.com/), [exotica](http://www.exotica.org.uk/), [hol abime](https://hol.abime.net/) or [C64](https://www.c64.com/) - Amiga / Commodore 64 Games
 * [World of Spectrum](https://worldofspectrum.org/) or [SpectrumComputing](https://spectrumcomputing.co.uk/) - Sinclair ZX Spectrum Games
 * [pc-98](https://rentry.co/FMHYBase64#pc-98) - PC-98 Games
 * [Necromanthus](https://necromanthus.com/) - 3D Shockwave Games
 * [NBlood](https://github.com/nukeykt/NBlood) - Reverse-Engineered Ports of Build Games
 * [LegendsWorld](https://www.legendsworld.net/) - Retro PC Adventure Games
-* [The Interactive Fiction Page](https://www.cs.cmu.edu/~wsr/IF/) - Interactive Fiction Games
 * [VGPErson](https://vgperson.com/games/) or [Japanese PC Compendium](https://japanesepccompendium.blogspot.com/) - Japanese PC Games
 * [Minetest](https://www.minetest.net/) or [Cassicube](https://www.classicube.net/) - Open-Source Minecraft Alternatives
 * [Grasscutter](https://github.com/Grasscutters/Grasscutter) - Private Genshin Impact Servers / [Discord](https://discord.gg/T5vZU6UyeG)
 * [LunarCore](https://github.com/Melledy/LunarCore) - Private Honkai: Star Rail Servers
 * [OpenFortress](https://openfortress.fun/) - Team Fortress 2 Mod
 * [TF2 Classic](https://tf2classic.com/) - Team Fortress 2 Classic Mod
-* [Rekt](https://discord.com/invite/HqjQFCp) - Black Ops 1 Mod Projects
 * [Plutonium](https://plutonium.pw/) - Black Ops 2 / MW3 Mod Project / [Discord](https://discord.gg/d95y8ah)
 * [VeniceUnleashed - BF3](https://veniceunleashed.net/) or [Warsaw-Revamped - BF4](https://warsaw-revamped.com/) - Battlefield Mod Projects
-* [Classic DOOM](https://classicdoom.com/) or [DoomWorld](https://www.doomworld.com/) - Doom Downloads
-* [Doom64 EX](https://doom64ex.wordpress.com/downloads/) - Doom 64 PC Port
-* [dhewm3](https://dhewm3.org/) - Doom 3 Source Port
 * [Megaman 2.5D](https://petersjostrand.com/) - Multiplayer Mega Man
 * [OpenRA](https://openra.net/) - Command & Conquer Recreation
 * [NolfRevival](http://nolfrevival.tk/) - NOLF, NOLF 2 & Contract Jack
 * [DFWorkshop](https://www.dfworkshop.net/) - Daggerfall Unity Engine Port
 * [OpenMW](https://openmw.org/en/) - Morrowind Remake / [GitHub](https://github.com/OpenMW/openmw) / [Multiplayer](https://github.com/TES3MP/TES3MP)
 * [Old School RuneScape](https://oldschool.runescape.com/) - Classic Runescape
-* [rottexpr](https://github.com/LTCHIPS/rottexpr) - Rise of the Triad Source Port
 * [ECWolf](https://maniacsvault.net/ecwolf/) - Wolfenstein 3D, Spear of Destiny & Super 3D Noah's Ark Port
 * [ET: Legacy](https://www.etlegacy.com/) - Wolfenstein Enemy Territory Multiplayer Project / [Discord](https://discord.gg/UBAZFys)
 * [OpenArena Live](https://kosmi.io/openarena) - Quake 3 Arena Clone
@@ -268,9 +254,7 @@
 * [Marios Alternative](https://rentry.co/FMHYBase64#hacked-super-mario) - Hacked Super Mario ROMs
 * [SMWCentral](https://smwcentral.net/) - Hacked Super Mario World ROMs
 * [Wario Land Hack Vault](https://wario-land.github.io/HackVault/index.html) - Hacked Wario Land ROMs
-* [DoomsHack](https://doomshack.org/), [Doom Pastebin](https://pastebin.com/3DWF3Msq) or [Doom Wad Station](https://www.doomwadstation.net/) - Doom WADs
 * [POP Unofficial Website](https://popuw.com/) - Prince of Persia ROMs / Mods
-* [DOOM FX](https://github.com/RandalLinden/DOOM-FX) - Doom SNES Source Code
 * [Ship of Harkinian](https://github.com/HarbourMasters/Shipwright) - Ocarina of Time PC Port
 * [Super Mario Bros Crossover](https://archive.org/details/SuperMarioCrossoverOffline) - Play SMB with Alternative Characters
 * [perfect_dark](https://github.com/fgsfdsfgs/perfect_dark), [2](https://github.com/n64decomp/perfect_dark) - Perfect Dark Decompilation
@@ -335,39 +319,28 @@
 * ⭐ **[Newgrounds](https://www.newgrounds.com/games)** - Browser Games
 * ⭐ **[Ninjakiwi](https://ninjakiwi.com/archive)** - Bloons / Multiplayer / Steam Needed
 * ⭐ **[Line Rider](https://www.linerider.com/)** - Draw Sled Tracks
-* ⭐ **[Play-CS](https://play-cs.com/)** - Browser Counter-Strike 1.6
 * ⭐ **[Cookie Consent Speed.Run](https://cookieconsentspeed.run/)** - Cookie Disabling Game
 * ⭐ **[QWOP](https://www.foddy.net/Athletics.html)** - Ragdoll Running Game
-* ⭐ **[Free Rice](https://freerice.com/)** - Earn Rice for the World Food Programme, turn off adblocker
+* ⭐ **[Free Rice](https://freerice.com/)** - Earn Rice for the World Food Programme
 * [/r/WebGames](https://reddit.com/r/WebGames) - Browser Games Subreddit
 * [Armor Games](https://armorgames.com/) - Browser Games
 * [Kongregate](https://www.kongregate.com/) - Browser Games
-* [Weboasis Arcade](https://weboasis.app/arcade/) - Browser Games
 * [Addicting Games](https://www.addictinggames.com/) - Browser Games
-* [Miniclip](https://miniclip.com/) - Browser Games
-* [Nitrome](https://www.nitrome.com/) - Browser Games
 * [Y8](https://www.y8.com/) - Browser Games
 * [Crazy Games](https://www.crazygames.com/) - Browser Games
 * [GamezHero](https://www.gamezhero.com/) - Browser Games
-* [Yandex Games](https://yandex.com/games/) - Browser Games
 * [Nicky Case](https://ncase.me/) - Browser Games
 * [yell0wsuit](https://yell0wsuit.page/games.html) - Browser Games
-* [Gamaverse](https://gamaverse.com/) - Browser Games
 * [N-Arcade](https://n-arcade.io/) - Browser Games
 * [watabou](https://watabou.itch.io/) - Browser Games
-* [GameKB](https://www.gamekb.com/) - Browser Games
 * [DAN-BALL](https://dan-ball.jp/en/) - Browser Games
-* [CoolMathGames](https://www.coolmathgames.com/) - Browser Game Site (disguised as edu games)
 * [Spatial](https://www.spatial.io/) - 3D Browser Games
-* [Flash by Night](http://flashbynight.com/), [FlashMuseum](https://flashmuseum.org/), [FlashGamesArchive](http://www.flashgamearchive.com/playable/), [Flash Arch](https://flasharch.com/en) or [AlbinoBlackSheep](https://www.albinoblacksheep.com/games/) - Flash Games
+* [FlashMuseum](https://flashmuseum.org/), [Flash Arch](https://flasharch.com/en) or [AlbinoBlackSheep](https://www.albinoblacksheep.com/games/) - Flash Games
 * [Arcade Prehacks](https://www.arcadeprehacks.com/), [SamsHackedGames](https://www.samshackedgames.com/) or [KongHack](https://konghack.com/) - Flash Game Hacks
 * [HTML5 Games](https://html5games.com/) / [Browser](https://html5.thebestarcadescript.com/) - HTML5 Games
 * [iogames.space](https://iogames.space/), [itch.io](https://graebor.itch.io/), [Kindanice](https://kindanice.itch.io/), [Jezzamon](https://jezzamon.itch.io/), [Modd.io](https://www.modd.io/) or [Kevin Games](https://kevin.games/)- .io Games
 * [Games on GitHub](https://github.com/leereilly/games) - GitHub Hosted Games
-* [SpacebarCounter](https://spacebarcounter.io/spacebar-games.html) - Spacebar Games
 * [Lego Games](https://www.lego.com/en-us/kids/games) - Lego Browser Games
-* [WBKidsGo](https://www.wbkidsgo.com/) or [PBS Kids Games](https://pbskids.org/games/) - Kids Browser Games
-* [RobotStreamer](https://robotstreamer.com/) - Live Control Robots
 * [Free Rider HD](https://www.freeriderhd.com/) - Draw / Race Bike Tracks
 * [BananaBread](https://kripken.github.io/misc-js-benchmarks/banana/index.html) - Browser Bot FPS
 * [Dynast](https://dynast.io/) - Survival Browser Game
@@ -633,7 +606,6 @@
 * [Wordlevs](https://wordlevs.com/)
 * [Octordle](https://www.britannica.com/games/octordle/)
 * [Wordless](https://lessgames.com/wordless) 
-* [LoLdle](https://loldle.net/) - League of Legends Style Wordle
 * [Minecraftle](https://minecraftle.zachmanson.com/) - Minecraft Crafting Style Wordle
 
 ***
@@ -685,7 +657,6 @@
 * [Otis_Inf Camera Mods](https://redd.it/hvttbd) - Game Camera Mods Index
 * [ProAsm](http://www.proasm.com/) - Retro Game Mods
 * [Top Mods](https://www.top-mods.com/) - PC Game Mods
-* [Realm667](https://www.realm667.com/index.php/en/) - Doom Mods
 * [Unreal Archive](https://unrealarchive.org/index.html) - Unreal Tournament Mods, Maps, Skins etc.
 * [Quaddicted](https://www.quaddicted.com/) - Classic Quake Mods, Maps & Tools
 * [ZagruzkaMods](https://zagruzkamods.com/) or [GameJunkie](https://www.gamejunkie.pro/) - Simulator Game Mods
@@ -991,9 +962,6 @@
 * [NV:MP](https://nv-mp.com/) - Fallout: New Vegas Multiplayer
 * [Project Cartographer](https://www.halo2.online/) - Halo 2 Online Servers
 * [Halo Custom Edition](https://www.haloce.org/) - Halo CE Online Servers
-* [csgo-mm-server-picker](https://github.com/Jyben/csgo-mm-server-picker) - CS:GO Server Picker
-* [Simple Radar](https://readtldr.gg/simpleradar) - Improved CS:GO Radar
-* [CSGO Trader](https://csgotrader.app/) - CS:GO Trading Enhancements
 * [Northstar](https://northstar.thunderstore.io/), [2](https://northstar.tf/) - Titanfall 2 Server Hosting & Modding / [GitHub](https://github.com/R2Northstar/Northstar/releases) / [Guide](https://rentry.org/northstar-guide) / [Discord](https://discord.gg/CEszSguY3A)
 * [CnCNet](https://cncnet.org/) - Multiplayer Command & Conquer 
 * [Rusticaland](https://rusticaland.net/) - Rust Cracked Client / Servers
@@ -1003,28 +971,13 @@
 * [FaceItFinder](https://faceitfinder.com/) - FaceIt Stats Search
 * [BF2142 Reclamation](https://battlefield2142.co/) - BF2142 Multiplayer Project / [Discord](https://discord.gg/MEwBW9U)
 * [Mobalytics](https://mobalytics.gg/) - Game Performance & Stats Analyzer
-* [HLTV](https://www.hltv.org/) - Counter-Strike Leaderboards
-* [CS2 Browser](https://cs2browser.com/) - Counter Strike 2 Server Browser
 * [StatsVerse](http://statsverse.com/) - Battlefield Leaderboards
 * [Sym.gg](https://sym.gg/) - Battlefield Info & Weapon Stats
 * [PaladinsGuru](https://paladins.guru/) - Paladins Leaderboards
 * [TrueGameData](https://truegamedata.com/) - COD Leaderboards
 * [Warzone Loadout](https://warzoneloadout.games/) - Warzone Loadouts and Builds
 * [Braytech](https://bray.tech/) - Destiny 2 Stats
-* [PUBG Damage Sheet](https://www.wackyjacky101.com/damage-sheet) - PUBG Battlegrounds Damage Sheet
 * [Leaf](https://leafapp.co/) or [HaloDataHive](https://halodatahive.com/) - Halo Infinite Leaderboards / Stats
-* [DMZ Calculator](https://sebranly.github.io/dmz/) - DMZ Currency to Cooldown Converter
-* [u.gg](https://u.gg/), [MobaFire](https://www.mobafire.com/), [ProBuilds](https://www.probuilds.net/) or [LoLalytics](https://lolalytics.com/) - League of Legends Build Guides & Tiers
-* [Zar](https://zar.gg) - LoL In-Game Coaching Overlay
-* [LoL Math](https://lolmath.net/) - League of Legends Build Calculator
-* [League of Graphs](https://www.leagueofgraphs.com/) - Champion Rankings
-* [DraftGap](https://draftgap.com/) - League of Legends Drafting Tool
-* [Rewind.lol](https://rewind.lol/) - League of Legends Match History
-* [OP.GG](https://www.op.gg/) - League of Legends Leaderboards / Stats
-* [Porofessor](https://porofessor.gg/) - Live League of Legends Game Stats
-* [ProStreams](https://prostreams.gg/) - Watch Pro Twitch LoL Streams
-* [Dota2ProTracker](https://www.dota2protracker.com/) or [16-Bits](https://16-bits.org/) - Dota 2 Stats Tracker
-* [SmiteGuru](https://smite.guru/) - Smite Leaderboards
 * [D4Builds](https://d4builds.gg/) - Diablo 4 Builds
 * [WoWProgress](https://www.wowprogress.com) or [CheckPVP](https://www.check-pvp.fr/) - WoW Rankings
 * [FallGuysStats](https://github.com/ShootMe/FallGuysStats) or [Fallalytics](https://fallalytics.com/) - Fall Guys Stat Trackers
@@ -1121,6 +1074,35 @@
 
 ***
 
+## ▷ MOBA Tools
+
+* ⭐ **[OP.GG](https://www.op.gg/)** - LoL Player Background Check
+* ⭐ **[U.GG](https://u.gg/)** - LoL Champion Builds / Tiers
+* [MobaFire](https://www.mobafire.com/) - LoL Champion Guides
+* [ProBuilds](https://www.probuilds.net/) - LoL Pro Player Builds
+* [Zar](https://zar.gg) - LoL In-Game Coaching Overlay
+* [DraftGap](https://draftgap.com/) - LoL Draft Analysis Tool
+* [Porofessor](https://porofessor.gg/) - Live LoL Game Stats
+* [ProStreams](https://prostreams.gg/) - Watch Pro LoL Twitch Streams
+* [LoLdle](https://loldle.net/) - League of Legends Wordle
+* [Dota2ProTracker](https://www.dota2protracker.com/) or [16-Bits](https://16-bits.org/) - Dota 2 Stats Tracker
+* [SmiteGuru](https://smite.guru/) - Smite Leaderboards
+
+***
+
+## ▷ Counter-Srike Tools
+
+* ⭐ **[CsWarzOnE](https://cswarzone.com/)** - Counter-Strike Downloads
+* ⭐ **[Play-CS](https://play-cs.com/)** - Browser Counter-Strike 1.6
+* [csgo-mm-server-picker](https://github.com/Jyben/csgo-mm-server-picker) - CS:GO Server Picker
+* [Simple Radar](https://readtldr.gg/simpleradar) - Improved CS:GO Radar
+* [CSGO Trader](https://csgotrader.app/) - CS:GO Trading Enhancements
+* [ArminC-AutoExec](https://github.com/ArmynC/ArminC-AutoExec) - ArminC's CS:GO Config
+* [HLTV](https://www.hltv.org/) - Counter-Strike Leaderboards
+* [CS2 Browser](https://cs2browser.com/) - Counter-Strike 2 Server Browser
+
+***
+
 ## ▷ GTA Tools
 
 * 🌐 **[GTAAll](https://www.gtaall.com/)**, [GTAInside](https://gtainside.com/), [GameModding](https://gamemodding.com/), [GTAGarage](https://gtagarage.com/) or [LibertyCity](https://libertycity.net/) - GTA Mods, Cheats, Walkthroughs & More
@@ -1132,6 +1114,19 @@
 * [OpenIV](https://openiv.com/) - Rockstar Game Modding Tool
 * [D.E.P](https://www.definitive-edition-project.com/) - Fix GTA PC Port Bugs
 * [Vice City: Multiplayer](https://vc-mp.org/) - Mutiplayer GTAVC
+
+***
+
+## ▷ Doom Tools
+
+* ⭐ **[ZDoom](https://www.zdoom.org/downloads)** - Doom Source Port
+* ⭐ **[ZDaemon](https://www.zdaemon.org/)**, **[Doomseeker](https://doomseeker.drdteam.org/)**, [oDamex](https://odamex.net/), [DoomUtils](http://doomutils.ucoz.com/) or [Zandronum](https://zandronum.com/) - Online Multiplayer Doom
+* [Realm667](https://www.realm667.com/index.php/en/) - Doom Mods
+* [Classic DOOM](https://classicdoom.com/) or [DoomWorld](https://www.doomworld.com/) - Doom Downloads
+* [Doom64 EX](https://doom64ex.wordpress.com/downloads/) - Doom 64 PC Port
+* [dhewm3](https://dhewm3.org/) - Doom 3 Source Port
+* [DoomsHack](https://doomshack.org/), [Doom Pastebin](https://pastebin.com/3DWF3Msq) or [Doom Wad Station](https://www.doomwadstation.net/) - Doom WADs
+* [DOOM FX](https://github.com/RandalLinden/DOOM-FX) - Doom SNES Source Code
 
 ***
 
@@ -1250,7 +1245,6 @@
 * ⭐ **[Momentum](https://momentum-mod.org/)** - Movement Training
 * [GameGuides](https://www.gamerguides.com/), [Retro Guides](https://rentry.co/FMHYBase64#retro-game-strategy-guides), [Game8](https://game8.co/), [StrategyWiki](https://strategywiki.org/), [Samurai Gamers](https://samurai-gamers.com/), [UHS Hints](https://www.uhs-hints.com/) or [Kirklands](https://archive.org/details/kirklands-manual-labor-sony-playstation-2-usa-4k-version) - Game Guides
 * [Piper](https://github.com/libratbag/piper) - Gaming Mouse Config Tool
-* [ArminC-AutoExec](https://github.com/ArmynC/ArminC-AutoExec) - ArminC's CS:GO Config
 * [Use ESDF](http://www.use-esdf.org/) - OG FPS Control Combo
 * [LiveSplit](https://livesplit.org/) - Customizable Speedrun Timer
 * [TASVideos](https://tasvideos.org/) - Watch and Publish Tool Assisted Speedruns


### PR DESCRIPTION
- Added sub categories for MOBA, CS and Doom Tools since there were many links related to those
- Reorganized some stuff and fixed descs
- Starred OP.GG and U.GG in LoL Tools, they're the most popular and useful tools for league
- Removed [The Interactive Fiction Page](https://www.cs.cmu.edu/~wsr/IF/), last update 2003, no longer maintained, niche
- Removed [Rekt](https://discord.com/invite/HqjQFCp), dead server
- Removed [rottexpr](https://github.com/LTCHIPS/rottexpr), no update for 4 years, niche
- Removed [Weboasis Arcade](https://weboasis.app/arcade/), not that many games and nothing special
- Removed [Miniclip](https://miniclip.com/), only 2 browser games available, the rest is mobile games
- Removed [Nitrome](https://www.nitrome.com/), not that many browser games
- Removed [Yandex Games](https://yandex.com/games/), mostly cringe/kids games
- Removed [Gamaverse](https://gamaverse.com/), awful games
- Removed [GameKB](https://www.gamekb.com/), cringe games and awful UI
- Removed [CoolMathGames](https://www.coolmathgames.com/), mostly games for kids and identical to sites listed in the index
- Removed [Flash by Night](http://flashbynight.com/), not that many games and nothing unique
- Removed [FlashGamesArchive](http://www.flashgamearchive.com/playable/), most games aren't playable
- Removed [SpacebarCounter](https://spacebarcounter.io/spacebar-games.html), only 3 games
- Removed [WBKidsGo](https://www.wbkidsgo.com/) and [PBS Kids Games](https://pbskids.org/games/), just bad games for 5 year olds
- Removed [RobotStreamer](https://robotstreamer.com/), unsure what it is but it definitely isn't browser games site
- Removed [PUBG Damage Sheet](https://www.wackyjacky101.com/damage-sheet) and [DMZ Calculator](https://sebranly.github.io/dmz/), too niche, see https://discord.com/channels/956006107564879872/986617857133649921/1213504417169678389
- Removed a bunch of LoL stuff that was useless and not any better than the starred stuff