### PR TITLE
Remove aiseesoft, add dewatermark

### DIFF
--- a/img-tools.md
+++ b/img-tools.md
@@ -603,7 +603,7 @@
 * [Lithophane](https://3dp.rocks/lithophane) - Image to Lithophane Converter
 * [WhatTheFont](https://www.myfonts.com/) - Find Font from Image
 * [RemoveWatermark](https://removewatermark.ai/), [Watermarkly](https://watermarkly.com/) or [Watermarkup](https://watermarkup.com/watermark.html) - Image Watermarking
-* [Watermark Remover Online](https://www.aiseesoft.com/watermark-remover-online/) or [Watermark Remover](https://www.watermarkremover.io/) - Watermark Removal
+* [Watermark Remover](https://www.watermarkremover.io/) or [DeWatermark](https://dewatermark.ai/) - Watermark Removal
 * [Glaze](https://glaze.cs.uchicago.edu/index.html) or [Nightshade](https://nightshade.cs.uchicago.edu/downloads.html) - Protect Digital Art from AI Copies
 * [FPNG](https://github.com/richgel999/fpng) - PNG Reader / Writer
 * [APNG Maker](https://rukario.github.io/Schande/Uninteresting%20stuff/APNG%20Maker.html) - Create / Optimize APNG Images


### PR DESCRIPTION
## Description
The aiseesoft one is basically just content aware fill. It's useless for all but a few watermarks.

DeWatermark is more similar to WatermarkRemover.io; it's automatic and actually just targets the watermarks.

## Context
Aiseesoft is useless, DeWatermark is better

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [x] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [x] I have made sure to [search](https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page) before making any changes. 
- [x] My code follows the code style of this project.
