### PR TITLE
Update devtools

### DIFF
--- a/DEVTools.md
+++ b/DEVTools.md
@@ -324,17 +324,15 @@
 
 * 🌐 **[Awesome Regex](https://github.com/aloisdg/awesome-regex)** - Regex Resources
 * ⭐ **[Regex Vis](https://regex-vis.com/)** - Regex Visualizer
-* ⭐ **[Regex Learn](https://regexlearn.com/)** or [refrf.dev](https://refrf.dev/) - Learn Regex
+* ⭐ **[Regex Learn](https://regexlearn.com/)**, [refrf.dev](https://refrf.dev/) or [learn-regex](https://github.com/ziishaned/learn-regex) - Learn Regex
 * ⭐ **[RegExr](https://regexr.com/)** or [Regex101](https://regex101.com/) - Regex Editors
-* ⭐ **[grex](https://pemistahl.github.io/grex-js/)** - Regex Generator
+* ⭐ **[grex](https://pemistahl.github.io/grex-js/)** or [Regex Generator](https://regex-generator.olafneumann.org/) - Regex Generator
 * [RegexOne](https://regexone.com/) - Regex Practice
 * [iHateRegex](https://ihateregex.io/) - Regex Patterns
-* [learn-regex](https://github.com/ziishaned/learn-regex) - Learn Regex
-* [Regex Generator](https://regex-generator.olafneumann.org/) - Regex Generator
 * [PyRegex](http://www.pyregex.com/) - Python Regex Test
 * [Melody](https://yoav-lavi.github.io/melody/book/) - Compile to Regex / [GitHub](https://github.com/yoav-lavi/melody)
-* [Regulex](https://jex.im/regulex/) - Regex Visualizers
-* [Regexper](https://regexper.com/) - Regex Visualizers
+* [Regulex](https://jex.im/regulex/) - Regex Visualizer
+* [Regexper](https://regexper.com/) - Regex Visualizer
 
 ***
 

--- a/DEVTools.md
+++ b/DEVTools.md
@@ -324,9 +324,9 @@
 
 * 🌐 **[Awesome Regex](https://github.com/aloisdg/awesome-regex)** - Regex Resources
 * ⭐ **[Regex Vis](https://regex-vis.com/)** - Regex Visualizer
-* ⭐ **[Regex Learn](https://regexlearn.com/)**, [refrf.dev](https://refrf.dev/) or [learn-regex](https://github.com/ziishaned/learn-regex) - Learn Regex
+* ⭐ **[RegexLearn](https://regexlearn.com/)**, [refrf.dev](https://refrf.dev/) or [learn-regex](https://github.com/ziishaned/learn-regex) - Learn Regex
 * ⭐ **[RegExr](https://regexr.com/)** or [Regex101](https://regex101.com/) - Regex Editors
-* ⭐ **[grex](https://pemistahl.github.io/grex-js/)** or [Regex Generator](https://regex-generator.olafneumann.org/) - Regex Generator
+* ⭐ **[grex](https://pemistahl.github.io/grex-js/)** or [Regex Generator](https://regex-generator.olafneumann.org/) - Regex Generators
 * [RegexOne](https://regexone.com/) - Regex Practice
 * [iHateRegex](https://ihateregex.io/) - Regex Patterns
 * [PyRegex](http://www.pyregex.com/) - Python Regex Test

--- a/DEVTools.md
+++ b/DEVTools.md
@@ -330,7 +330,7 @@
 * [RegexOne](https://regexone.com/) - Regex Practice
 * [iHateRegex](https://ihateregex.io/) - Regex Patterns
 * [Melody](https://yoav-lavi.github.io/melody/book/) - Compile to Regex / [GitHub](https://github.com/yoav-lavi/melody)
-* [PyRegex](http://www.pyregex.com/) - Python Regex Test
+* [PyRegex](http://www.pyregex.com/) - Python Regex Playground
 * [Regulex](https://jex.im/regulex/) - Regex Visualizer
 * [Regexper](https://regexper.com/) - Regex Visualizer
 

--- a/DEVTools.md
+++ b/DEVTools.md
@@ -14,7 +14,6 @@
 * [Python Cheatsheet](https://github.com/gto76/python-cheatsheet) or [SpeedSheet](https://speedsheet.io/) or [python-cheatsheet](https://gto76.github.io/python-cheatsheet/) - Python Cheat Sheets
 * [cppreference](https://en.cppreference.com/w/) - C++ Cheat Sheets
 * [React Typescript Cheatsheet](https://react-typescript-cheatsheet.netlify.app) - React Typescript Cheat Sheets
-* [Regex Hub](https://projects.lukehaas.me/regexhub/) or [IHateRegex](https://ihateregex.io/) - Regex Cheat Sheets
 * [SQL Cheat Sheet](https://i.ibb.co/Ctr0Tn8/e289a15e2246.jpg) - SQL Cheat Sheet
 * [CSS Cheat Sheet](https://docs.emmet.io/cheat-sheet/) or [CSS Tricks](https://css-tricks.com/snippets/) - CSS Cheat Sheet
 * [Easings](https://easings.net/) - CSS Animation Cheat Sheet
@@ -73,7 +72,6 @@
 * [Learn Perl](https://www.learn-perl.org/) - Learn Perl
 * [Rust Learning](https://github.com/ctjhoa/rust-learning) - Rust Learning Resources
 * [explaine.rs](https://jrvidal.github.io/explaine.rs/) - Rust Syntax Explanation
-* [learn-regex](https://github.com/ziishaned/learn-regex), [ReFrF](https://refrf.dev/), [Regex.info](http://regex.info/), [ReGexOne](https://regexone.com/), [RegExr](https://regexr.com/) or [RegexLearn](https://regexlearn.com/) - Learn Regex
 * [High Assurance Rust](https://highassurance.rs/) - Software Development Guide
 * [LearnOpenGL](https://learnopengl.com/) - Learn OpenGL
 * [Devops Exercises](https://github.com/bregman-arie/devops-exercises) - DevOps Exercises
@@ -319,6 +317,24 @@
 * [Copetti](https://www.copetti.org/) - In-depth Console Architecture Analysis / [GitHub](https://github.com/flipacholas/Architecture-of-consoles)
 * [CPU Land](https://cpu.land/) - What Happens when you run Programs
 * [Computer Science Lecture Links](https://github.com/riti2409/Resources-for-preparation-Of-Placements)
+
+***
+
+## ▷ Regex
+
+* 🌐 **[Awesome Regex](https://github.com/aloisdg/awesome-regex)** - Regex Resources
+* ⭐ **[Regex Vis](https://regex-vis.com/)** - Regex Visualizer
+* ⭐ **[Regex Learn](https://regexlearn.com/)** or [refrf.dev](https://refrf.dev/) - Learn Regex
+* ⭐ **[RegExr](https://regexr.com/)** or [Regex101](https://regex101.com/) - Regex Editors
+* ⭐ **[grex](https://pemistahl.github.io/grex-js/)** - Regex Generator
+* [RegexOne](https://regexone.com/) - Regex Practice
+* [iHateRegex](https://ihateregex.io/) - Regex Patterns
+* [learn-regex](https://github.com/ziishaned/learn-regex) - Learn Regex
+* [Regex Generator](https://regex-generator.olafneumann.org/) - Regex Generator
+* [PyRegex](http://www.pyregex.com/) - Python Regex Test
+* [Melody](https://yoav-lavi.github.io/melody/book/) - Compile to Regex / [GitHub](https://github.com/yoav-lavi/melody)
+* [Regulex](https://jex.im/regulex/) - Regex Visualizers
+* [Regexper](https://regexper.com/) - Regex Visualizers
 
 ***
 
@@ -1071,7 +1087,6 @@
 
 * 🌐 **[BenchmarksGame](https://benchmarksgame-team.pages.debian.net/benchmarksgame/)** or [Language Benchmarks](https://programming-language-benchmarks.vercel.app/) - Language Comparisons
 * 🌐 **[Awesome Programming](https://github.com/hardikvasa/awesome-programming)**, [Best-Websites](https://github.com/sdmg15/Best-websites-a-programmer-should-visit), [Tiny Tools](https://tinytools.directory/), [CarlosAG](https://www.carlosag.net/) or [Charm](https://charm.sh/) - Programming Resources
-* 🌐 **[Awesome Regex](https://github.com/aloisdg/awesome-regex)** - Regex Resources
 * 🌐 **[Awesome-Discord-Communities](https://github.com/mhxion/awesome-discord-communities)** - Discord Communities 
 * 🌐 **[Programming-Telegram-Group](https://github.com/hendisantika/List-All-Programming-Telegram-Group)** - Telegram Communities
 * 🌐 **[Awesome Twitter Communities](https://github.com/mattn/awesome-twitter-communities)** - Twitter Communities
@@ -1079,12 +1094,8 @@
 * ⭐ **[Literally Anything](https://www.literallyanything.io/)** - Generate Code via Prompts
 * ⭐ **[RevShells](https://www.revshells.com/)** - Reverse Shell Generator
 * ⭐ **[JSON Hero](https://jsonhero.io/)**, [Jayson](https://apps.apple.com/us/app/jayson/id1447750768) or [JSONView](https://jsonview.com/) - JSON Viewers / Editors
-* ⭐ **[Regex Vis](https://regex-vis.com/)**, [Regulex](https://jex.im/regulex/) or [Regexper](https://regexper.com/) - Regex Visualizers / [Batch Editor](https://github.com/antfu/rex)
-* ⭐ **[grex](https://pemistahl.github.io/grex-js/)**, [Regex Generator++](http://regex.inginf.units.it/) or [Regex Generator](https://regex-generator.olafneumann.org/) - Regex Generators
 * [Node-RED](https://nodered.org/) - Low-Code Programming for Event-Driven Apps
 * [Commands.dev](https://www.commands.dev/) - Terminal Commands
-* [Regex101](https://regex101.com/), [Debuggex](https://www.debuggex.com/) or [Cyrilex](https://extendsclass.com/regex-tester.html) - Regex Editor / Debuggers
-* [AutoRegex](https://www.autoregex.xyz/) - AI-based Regex Generator
 * [AirBroke](https://airbroke.icorete.ch/) or [Glitchtip](https://glitchtip.com) - Error Tracking Platforms
 * [Algorithm Visualizer](https://algorithm-visualizer.org/) or [Sorting Algorithms Visuallizer](https://sadanandpai.github.io/algo-visualizers/#/sorting-visualizer/bubble) / [GitHub](https://github.com/sadanandpai/sorting-visualizer) - Visualize Code Algorithms 
 * [Code2Flow](https://app.code2flow.com/), [Flowchart.js](https://flowchart.js.org/) or [Flowchart Generator](https://github.com/MugilanGN/Flowchart-Generator) - Code to Flowchart Converter
@@ -1119,7 +1130,6 @@
 * [Dodgy](https://github.com/landscapeio/dodgy) - Find PWs & Diffs in Python Code
 * [pointers.py](https://github.com/ZeroIntensity/pointers.py) - Python Pointers
 * [Pyright](https://github.com/microsoft/pyright) or [mypy](https://github.com/python/mypy) - Python Static Type Checker
-* [PyRegex](http://www.pyregex.com/) - Python Regex Test
 * [Clean Code Python](https://github.com/zedr/clean-code-python) - Clean Up Python Code
 * [Translators](https://github.com/UlionTse/translators) - Translate Python Code
 * [strftime.net](https://strftime.net/) - Generate strftime Python Codes
@@ -1209,7 +1219,6 @@
 * [Tables Generator](https://www.tablesgenerator.com/) - Generates Tables in Various Languages
 * [WiredJS](https://wiredjs.github.io/designer/) - Wireframe Designer
 * [pueue](https://github.com/Nukesor/pueue) - Shell Command Manager
-* [Melody](https://yoav-lavi.github.io/melody/book/) - Programming Language to compile Regex / [GitHub](https://github.com/yoav-lavi/melody)
 * [Emojicode](https://www.emojicode.org/) - Emoji-Based Programming Language
 * [Crystalline](https://github.com/elbywan/crystalline) - Crystal Language Server
 * [icr](https://github.com/crystal-community/icr) - REPL for Crystal

--- a/DEVTools.md
+++ b/DEVTools.md
@@ -329,8 +329,8 @@
 * ⭐ **[grex](https://pemistahl.github.io/grex-js/)** or [Regex Generator](https://regex-generator.olafneumann.org/) - Regex Generators
 * [RegexOne](https://regexone.com/) - Regex Practice
 * [iHateRegex](https://ihateregex.io/) - Regex Patterns
-* [PyRegex](http://www.pyregex.com/) - Python Regex Test
 * [Melody](https://yoav-lavi.github.io/melody/book/) - Compile to Regex / [GitHub](https://github.com/yoav-lavi/melody)
+* [PyRegex](http://www.pyregex.com/) - Python Regex Test
 * [Regulex](https://jex.im/regulex/) - Regex Visualizer
 * [Regexper](https://regexper.com/) - Regex Visualizer
 


### PR DESCRIPTION
Changes:
- Made Regex section
- Removed:
	- AutoRegex (doesn't or barely functions)
	- Debuggex, Cyrilex, and ReX editors (lacking compared to others)
	- Regex.info (site forces you to use http, and just links to a book)
	- Regex Hub (broken patterns and lacking compared to others)
	- Regex Generator++ (outdated)
- Starred:
	- RegExr (amazing, fully featured editor)
	- Regex Learn (great resource for learning regex)