### PR TITLE
Bypass Paywalls updates

### DIFF
--- a/Beginners-Guide.md
+++ b/Beginners-Guide.md
@@ -34,7 +34,7 @@ No, don't do that. Windows Defender is more than enough to keep you safe, but if
 !!!warning Stay away from Avast, Norton, and McAfee, as these are "bloatware" and generally unsafe software.
 
  > How can I bypass a paywalled article?
-Use [this](https://twitter.com/Magnolia1234B/status/1779186360743592222) / [Fork](https://gitlab.com/stefano.rovelli.1989/bypass-paywalls-clean-filters) to read the article easily.
+Use [this](https://twitter.com/Magnolia1234B/status/1779050596181438791) / [Fork](https://gitlab.com/stefano.rovelli.1989/bypass-paywalls-clean-filters) to read the article easily.
 
 > How can I download an image from *insert stock image site*?
  You can use [this downloader](https://downloader.la/), and if it doesn't work you can find other stock image downloaders [here](https://fmhy.net/img-tools#stock-photos).

--- a/Beginners-Guide.md
+++ b/Beginners-Guide.md
@@ -34,7 +34,7 @@ No, don't do that. Windows Defender is more than enough to keep you safe, but if
 !!!warning Stay away from Avast, Norton, and McAfee, as these are "bloatware" and generally unsafe software.
 
  > How can I bypass a paywalled article?
-Use [this](https://bitbucket.org/magnolia1234/bypass-paywalls-firefox-clean/src/master/) / [2](https://gitlab.com/magnolia1234/bypass-paywalls-chrome-clean) to read the article easily. 
+Use [this](https://twitter.com/Magnolia1234B/status/1779186360743592222) / [Fork](https://gitlab.com/stefano.rovelli.1989/bypass-paywalls-clean-filters) to read the article easily.
 
 > How can I download an image from *insert stock image site*?
  You can use [this downloader](https://downloader.la/), and if it doesn't work you can find other stock image downloaders [here](https://fmhy.net/img-tools#stock-photos).

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -840,7 +840,7 @@
 * 🌐 **[Archive Buttons](https://www.archivebuttons.com/)** - Paywall Bypass Tools
 * 🌐 **[PaywallHub](https://paywallhub.com/)** - Paywall Bypass Tools
 * ⭐ **[wallabag](https://wallabag.nixnet.services/)** / [Discord Bot](https://github.com/FahadBinHussain/wallabot)
-* ⭐ **[Bypass Paywalls Clean filters](https://twitter.com/Magnolia1234B)** / [Fork](https://gitlab.com/stefano.rovelli.1989/bypass-paywalls-clean-filters)
+* ⭐ **[Bypass Paywalls Clean filters](https://twitter.com/Magnolia1234B/status/1779186360743592222)** / [Fork](https://gitlab.com/stefano.rovelli.1989/bypass-paywalls-clean-filters)
 * [Bypass paywalls for scientific documents](https://greasyfork.org/en/scripts/35521) - Bypass Scientific Document Paywalls
 * [unpaywall](https://unpaywall.org/) - Bypass Scholarly Article Paywalls
 * [Scribe](https://scribe.rip/), [freedium](https://freedium.cfd/ ) or [medium-forall](https://medium-forall.vercel.app/) - Medium Paywall Bypass

--- a/STORAGE.md
+++ b/STORAGE.md
@@ -840,7 +840,7 @@
 * 🌐 **[Archive Buttons](https://www.archivebuttons.com/)** - Paywall Bypass Tools
 * 🌐 **[PaywallHub](https://paywallhub.com/)** - Paywall Bypass Tools
 * ⭐ **[wallabag](https://wallabag.nixnet.services/)** / [Discord Bot](https://github.com/FahadBinHussain/wallabot)
-* ⭐ **[Bypass Paywalls Clean filters](https://twitter.com/Magnolia1234B/status/1779186360743592222)** / [Fork](https://gitlab.com/stefano.rovelli.1989/bypass-paywalls-clean-filters)
+* ⭐ **[Bypass Paywalls Clean filters](https://twitter.com/Magnolia1234B/status/1779050596181438791)** / [Fork](https://gitlab.com/stefano.rovelli.1989/bypass-paywalls-clean-filters)
 * [Bypass paywalls for scientific documents](https://greasyfork.org/en/scripts/35521) - Bypass Scientific Document Paywalls
 * [unpaywall](https://unpaywall.org/) - Bypass Scholarly Article Paywalls
 * [Scribe](https://scribe.rip/), [freedium](https://freedium.cfd/ ) or [medium-forall](https://medium-forall.vercel.app/) - Medium Paywall Bypass


### PR DESCRIPTION
## Description
- Added a link to Magnolia1234B's latest tweet, which provides the working download for the Bypass Paywalls extensions for both Chrome and Firefox.
- Updated the Beginners Guide by replacing the outdated links with the current ones for Bypass Paywalls.

## Context
- The WeTransfer download link pinned on Magnolia1234B's Twitter page has expired. To prevent confusion, I've updated the link on FMHY to specifically point to their latest tweet that includes a working download link.
- I'm not sure if this is relevant, but I thought it might be useful to mention: Magnolia1234B's tweet links to a download page for the Bypass Paywalls extensions for Firefox and Chrome. However, the fork provided links to a GitLab repository that contains adblock filters and userscripts for Bypass Paywalls. Although related, they are technically different content. I wasn't sure if you'd prefer to categorize them differently based on this information.

## Types of changes
- [x] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [x] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [x] I have made sure to [search](https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page) before making any changes. 
- [x] My code follows the code style of this project.
