### PR TITLE
Debloated Bypass Paywalls Section

### DIFF
--- a/AdblockVPNGuide.md
+++ b/AdblockVPNGuide.md
@@ -22,6 +22,7 @@
 * [Popupblocker All](https://addons.mozilla.org/en-US/firefox/addon/popupblockerall/), [PopUpOFF](https://romanisthere.github.io/PopUpOFF-Website/index.html) or [PopupBlocker](https://github.com/AdguardTeam/PopupBlocker) - Popup / New Tab Blockers
 * [Adguard](https://github.com/AdguardTeam/AdguardBrowserExtension#installation) - Adblocker
 * [Adblock Tester](https://adblock-tester.com/) or [AdBlocker Test](https://d3ward.github.io/toolz/adblock.html) - Adblocking Tests
+* [12ft.io](https://12ft.io/) - Share Ad-Free URLs
 
 ***
 

--- a/Internet-Tools.md
+++ b/Internet-Tools.md
@@ -126,6 +126,7 @@
 
 * [Bypass paywalls for scientific documents](https://greasyfork.org/en/scripts/35521) - Bypass Scientific Document Paywalls
 * [unpaywall](https://unpaywall.org/) - Bypass Scholarly Article Paywalls
+
 * [PressReader](https://greasyfork.org/en/scripts/39936) - Bypass PressReader Paywall
 * [Burles](https://burles.co/en/) - Paywall Bypass
 * [bypass-paywalls](https://github.com/iamadamdev/bypass-paywalls-chrome) - Paywall Bypass
@@ -136,6 +137,8 @@
 * [Smry.ai](https://www.smry.ai/) - Paywall Bypass
 * [Readium](https://sugoidesune.github.io/readium/) - Paywall Bypass
 * [shacklefree](https://www.shacklefree.in/) - Paywall Bypass
+
+* [Archive.is](https://archive.is/) or [Archive.org](https://archive.org/) - Archived Articles
 
 ***
 

--- a/Internet-Tools.md
+++ b/Internet-Tools.md
@@ -120,22 +120,18 @@
 
 ## ▷ Paywall Bypass
 
-* 🌐 **[Archive Buttons](https://www.archivebuttons.com/)** or [PaywallHub](https://paywallhub.com/) - Paywall Bypass Tools
-* ⭐ **[wallabag](https://wallabag.nixnet.services/)** - Paywall Bypass / [Discord Bot](https://github.com/FahadBinHussain/wallabot)
-* ⭐ **[Bypass Paywalls Clean](https://github.com/bpc-clone/bpc_updates/releases)** - Paywall Bypass / [Filter List](https://github.com/bpc-clone/bypass-paywalls-clean-filters) / [Twitter](https://twitter.com/Magnolia1234B)
-* ⭐ **[Freedium](https://freedium.cfd/)** - Bypass Medium Paywalls
+* ⭐ **[Bypass Paywalls Clean](https://github.com/bpc-clone/bpc_updates/releases)** - Browser Extensions / [Filter List](https://github.com/bpc-clone/bypass-paywalls-clean-filters) / [Twitter](https://twitter.com/Magnolia1234B)
+* ⭐ **[Freedium](https://freedium.cfd/)** or [Medium For All](https://medium-forall.vercel.app/) - Bypass Medium Paywalls
+* ⭐ **[wallabag](https://wallabag.org/)** / [Discord Bot](https://github.com/FahadBinHussain/wallabot) or [Ladder](https://github.com/everywall/ladder) - Self-Hosted
+
 * [Bypass paywalls for scientific documents](https://greasyfork.org/en/scripts/35521) - Bypass Scientific Document Paywalls
 * [unpaywall](https://unpaywall.org/) - Bypass Scholarly Article Paywalls
-* [Scribe](https://scribe.rip/) or [medium-forall](https://medium-forall.vercel.app/) - Medium Paywall Bypass
 * [PressReader](https://greasyfork.org/en/scripts/39936) - Bypass PressReader Paywall
-* [Ladder](https://github.com/everywall/ladder) - Self-Hosted Paywall Bypass
 * [Burles](https://burles.co/en/) - Paywall Bypass
 * [bypass-paywalls](https://github.com/iamadamdev/bypass-paywalls-chrome) - Paywall Bypass
 * [pocket](https://getpocket.com/) - Paywall Bypass
 * [Hover Paywalls](https://github.com/nathan-149/hover-paywalls-browser-extension) - Paywall Bypass
-* [medium-unlocker](https://github.com/und3fined/medium-unlocker) - Paywall Bypass
 * [OpenAccessButton](https://openaccessbutton.org/) - Paywall Bypass
-* [RemovePaywalls](https://www.removepaywall.com/) - Paywall Bypass
 * [PaywallBypasser](https://github.com/SybronH/PaywallBypasser) - Paywall Bypass
 * [Smry.ai](https://www.smry.ai/) - Paywall Bypass
 * [Readium](https://sugoidesune.github.io/readium/) - Paywall Bypass

--- a/Internet-Tools.md
+++ b/Internet-Tools.md
@@ -122,23 +122,15 @@
 
 * ⭐ **[Bypass Paywalls Clean](https://github.com/bpc-clone/bpc_updates/releases)** / [Filter List](https://github.com/bpc-clone/bypass-paywalls-clean-filters) / [Twitter](https://twitter.com/Magnolia1234B) - Browser Extensions
 * ⭐ **[Freedium](https://freedium.cfd/)** or [Medium For All](https://medium-forall.vercel.app/) - Bypass Medium Paywalls
+* ⭐ **[Archive.is](https://archive.is/)** - Archived Articles
 * ⭐ **[wallabag](https://wallabag.org/)** / [Discord Bot](https://github.com/FahadBinHussain/wallabot) or [Ladder](https://github.com/everywall/ladder) - Self-Hosted
 
 * [Bypass paywalls for scientific documents](https://greasyfork.org/en/scripts/35521) - Bypass Scientific Document Paywalls
 * [unpaywall](https://unpaywall.org/) - Bypass Scholarly Article Paywalls
 
-* [PressReader](https://greasyfork.org/en/scripts/39936) - Bypass PressReader Paywall
 * [Burles](https://burles.co/en/) - Paywall Bypass
-* [bypass-paywalls](https://github.com/iamadamdev/bypass-paywalls-chrome) - Paywall Bypass
-* [pocket](https://getpocket.com/) - Paywall Bypass
-* [Hover Paywalls](https://github.com/nathan-149/hover-paywalls-browser-extension) - Paywall Bypass
 * [OpenAccessButton](https://openaccessbutton.org/) - Paywall Bypass
-* [PaywallBypasser](https://github.com/SybronH/PaywallBypasser) - Paywall Bypass
-* [Smry.ai](https://www.smry.ai/) - Paywall Bypass
 * [Readium](https://sugoidesune.github.io/readium/) - Paywall Bypass
-* [shacklefree](https://www.shacklefree.in/) - Paywall Bypass
-
-* [Archive.is](https://archive.is/) or [Archive.org](https://archive.org/) - Archived Articles
 
 ***
 

--- a/Internet-Tools.md
+++ b/Internet-Tools.md
@@ -120,17 +120,13 @@
 
 ## ▷ Paywall Bypass
 
+* ⭐ **[Archive.is](https://archive.is/)** - Archived Articles
 * ⭐ **[Bypass Paywalls Clean](https://github.com/bpc-clone/bpc_updates/releases)** / [Filter List](https://github.com/bpc-clone/bypass-paywalls-clean-filters) / [Twitter](https://twitter.com/Magnolia1234B) - Browser Extensions
 * ⭐ **[Freedium](https://freedium.cfd/)** or [Medium For All](https://medium-forall.vercel.app/) - Bypass Medium Paywalls
-* ⭐ **[Archive.is](https://archive.is/)** - Archived Articles
 * ⭐ **[wallabag](https://wallabag.org/)** / [Discord Bot](https://github.com/FahadBinHussain/wallabot) or [Ladder](https://github.com/everywall/ladder) - Self-Hosted
-
 * [Bypass paywalls for scientific documents](https://greasyfork.org/en/scripts/35521) - Bypass Scientific Document Paywalls
 * [unpaywall](https://unpaywall.org/) - Bypass Scholarly Article Paywalls
-
-* [Burles](https://burles.co/en/) - Paywall Bypass
-* [OpenAccessButton](https://openaccessbutton.org/) - Paywall Bypass
-* [Readium](https://sugoidesune.github.io/readium/) - Paywall Bypass
+* [Open Access Button](https://openaccessbutton.org/) - Bypass Research Article Paywalls
 
 ***
 

--- a/Internet-Tools.md
+++ b/Internet-Tools.md
@@ -120,7 +120,7 @@
 
 ## ▷ Paywall Bypass
 
-* ⭐ **[Bypass Paywalls Clean](https://github.com/bpc-clone/bpc_updates/releases)** - Browser Extensions / [Filter List](https://github.com/bpc-clone/bypass-paywalls-clean-filters) / [Twitter](https://twitter.com/Magnolia1234B)
+* ⭐ **[Bypass Paywalls Clean](https://github.com/bpc-clone/bpc_updates/releases)** / [Filter List](https://github.com/bpc-clone/bypass-paywalls-clean-filters) / [Twitter](https://twitter.com/Magnolia1234B) - Browser Extensions
 * ⭐ **[Freedium](https://freedium.cfd/)** or [Medium For All](https://medium-forall.vercel.app/) - Bypass Medium Paywalls
 * ⭐ **[wallabag](https://wallabag.org/)** / [Discord Bot](https://github.com/FahadBinHussain/wallabot) or [Ladder](https://github.com/everywall/ladder) - Self-Hosted
 

--- a/Internet-Tools.md
+++ b/Internet-Tools.md
@@ -123,22 +123,20 @@
 * 🌐 **[Archive Buttons](https://www.archivebuttons.com/)** or [PaywallHub](https://paywallhub.com/) - Paywall Bypass Tools
 * ⭐ **[wallabag](https://wallabag.nixnet.services/)** - Paywall Bypass / [Discord Bot](https://github.com/FahadBinHussain/wallabot)
 * ⭐ **[Bypass Paywalls Clean](https://github.com/bpc-clone/bpc_updates/releases)** - Paywall Bypass / [Filter List](https://github.com/bpc-clone/bypass-paywalls-clean-filters) / [Twitter](https://twitter.com/Magnolia1234B)
+* ⭐ **[Freedium](https://freedium.cfd/)** - Bypass Medium Paywalls
 * [Bypass paywalls for scientific documents](https://greasyfork.org/en/scripts/35521) - Bypass Scientific Document Paywalls
 * [unpaywall](https://unpaywall.org/) - Bypass Scholarly Article Paywalls
-* [Scribe](https://scribe.rip/), [freedium](https://freedium.cfd/ ) or [medium-forall](https://medium-forall.vercel.app/) - Medium Paywall Bypass
+* [Scribe](https://scribe.rip/) or [medium-forall](https://medium-forall.vercel.app/) - Medium Paywall Bypass
 * [PressReader](https://greasyfork.org/en/scripts/39936) - Bypass PressReader Paywall
 * [Ladder](https://github.com/everywall/ladder) - Self-Hosted Paywall Bypass
 * [Burles](https://burles.co/en/) - Paywall Bypass
-* [Paywall Bypass Index](https://redd.it/rs9ej1) - Paywall Bypass
 * [bypass-paywalls](https://github.com/iamadamdev/bypass-paywalls-chrome) - Paywall Bypass
 * [pocket](https://getpocket.com/) - Paywall Bypass
-* [1ft.io](https://1ft.io/) - Paywall Bypass
 * [Hover Paywalls](https://github.com/nathan-149/hover-paywalls-browser-extension) - Paywall Bypass
 * [medium-unlocker](https://github.com/und3fined/medium-unlocker) - Paywall Bypass
 * [OpenAccessButton](https://openaccessbutton.org/) - Paywall Bypass
 * [RemovePaywalls](https://www.removepaywall.com/) - Paywall Bypass
 * [PaywallBypasser](https://github.com/SybronH/PaywallBypasser) - Paywall Bypass
-* [12ft.io](https://12ft.io/) - Paywall Bypass
 * [Smry.ai](https://www.smry.ai/) - Paywall Bypass
 * [Readium](https://sugoidesune.github.io/readium/) - Paywall Bypass
 * [shacklefree](https://www.shacklefree.in/) - Paywall Bypass

--- a/MISCGuide.md
+++ b/MISCGuide.md
@@ -375,6 +375,7 @@
 * [JustRead](https://justread.link/) or [Unclutter](https://unclutter.it/) - Feed Managers / Readers
 * [Google Alerts](https://www.google.com/alerts) - News Alerts by Topics
 * [Top Stories](https://murmel.social/top) - Top Fediverse News 
+* [Pocket](https://getpocket.com/) - Discover & Save Articles
 * [CBM](https://comicbookmovie.com/) - Comic / Movie / TV News
 * [Anime News Network](https://www.animenewsnetwork.com/) - Anime News
 * [Anime Corner](https://animecorner.me/) - Anime / Manga News

--- a/ReadingPiracyGuide.md
+++ b/ReadingPiracyGuide.md
@@ -770,7 +770,7 @@
 
 ## ▷ Documents / Articles
 
-* ↪️ **[Bypass Article Paywalls](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_read_paywalled_articles)**
+* ↪️ **[Bypass Article Paywalls](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/internet-tools#wiki_.25B7_paywall_bypass)**
 * ⭐ **[TheFreeLibrary](https://www.thefreelibrary.com/)** - Articles
 * ⭐ **[arXiv](https://arxiv.org/)** - Science / Math / Physics / [Search](https://arxiv-sanity-lite.com/) / [Chatbot](https://github.com/evanhu1/talk2arxiv)
 * [Wikisource](https://en.wikisource.org) - Poetry / Text / Documents


### PR DESCRIPTION
## Changes:

**Note**: All links were thoroughly tested with a variety of different paywalled articles. You can find the full list [here](https://rentry.co/vw6mqrko).

- Starred:
	- "Freedium" - Amazing site, works 100% of the time (except one instance[^1]), no ads, really fast load times, and is responsive so you can view articles on mobile devices.
	- "Archive.is" - Works surprisingly well, especially for particularly tricky sites, including Medium articles. It's also useful for rare instances when other solutions don't work. Archive.is can load article images, something Archive.org sometimes can't. it also loads archived pages a lot faster than Archive.org.
- Removed:
	- "12ft.io" - Very hit and miss, sites don't always work, and also has been repurposed since its last takedown to just remove popups, banners, and ads, which something like uBO would be better for. Some sites can work as a byproduct of this, but its not reliable enough.[^2]
	- "1ft.io" - Similar to "12ft.io", i.e. hardly works and isn't designed to bypass paywalls, only to remove ads, which again uBO is far better at.
	- "Paywall Bypass Index" - Outdated + FMHY has a better list now.
	- "medium-unlocker" - Still has unresolved issues from last year, the dev also recommends that you use a pre-release to have a good chance of articles being bypassed. Considering its a beta build, and with seemingly no active development in the last 9 months, the extension might not work all the time, be very buggy, or likely have many other problems like [compatibility](https://github.com/und3fined/medium-unlocker/issues/55) issues.
	- "Scribe" - Broken.
	- "RemovePaywall" - Hardly works for normal articles, doesn't work on medium articles, and is not reliable enough to keep.
	- "Archive Buttons" and "PaywallHub" - Useless.[^3]
	- "PressReader" - Broken + 6 years outdated.
	- "Smry.ai" - Barely works + Has a fake supported sites list.[^4]
	- "bypass-paywalls" - Only one or two sites worked when tested, also isn't as good as BPC or as powerful, with not as many supported sites either.
	- "shacklefree" - Only worked twice during my tests and sometimes loads articles with no CSS, so the viewing experience is awful.
	- "Readium" - Doesn't work + No updates in 4 years.
- Untested but still removed:
	- "PaywallBypasser" - No updates in a year, only 35 stars, doesn't seem useful.
	- "Hover Paywalls" - Last release 4 years ago, no active development, so likely doesn't work today.
- Other:
	- Fixed a redirect link for the section.
	- Moved Mozilla's Pocket to a more appropriate place.
	- Tidied up existing links.

[^1]: All the articles I tested worked perfectly, except [one](https://freedium.cfd/https://levelup.gitconnected.com/introducing-pandasai-the-generative-ai-python-library-568a971af014), which showed only a blank page with no article. All other articles I tested from the same domain (levelup.gitconnected.com) worked fine, so its highly likely this is **just a bug** and shouldn't affect whether it's starred or not, as it still works flawlessly and is super convenient. In the meantime, I've raised [an issue](https://codeberg.org/Freedium-cfd/web/issues/4) on the sites repository.
[^2]: Moved it under adblocking instead, since it works for simply sharing a cleaner version of a URL, which some might find useful.
[^3]: Both sites have buttons for the following: "archive.is", "archive.org", "removepaywall.com", "12ft.io", and "google cache", 4 of which are either useless or bad: Google cache was discontinued a while ago and no longer exists; "removepaywall.com" and "12ft.io" have been removed for reasons stated above; and "archive.org" is slow and doesn't always work. It also can't bypass Medium article paywalls; "archive.is" can. That leaves only "archive.is", which can just be linked separately. Additionally, the BPC extension [actually grabs content from "archive.is"](https://i.ibb.co/Ms31MLT/img.png) for certain articles, so sometimes you won't even need to use the archive site in a separate tab. It is for all these reasons that these 'buttons' are completely useless.
[^4]: It could go with "12ft.io" under adblocking because its similar, but I'm not sure how popular 'sharing clean article links' is. It seems pretty niche, so I kept it removed.