### PR TITLE
Removed IDM Trial Reset.md

### DIFF
--- a/File-Tools.md
+++ b/File-Tools.md
@@ -47,7 +47,7 @@
 * ⭐ **[Gopeed](https://gopeed.com/)** - Download Manager / [GitHub](https://github.com/GopeedLab/gopeed) / [Extension](https://github.com/GopeedLab/browser-extension) / [Plugins](https://github.com/search?q=topic%3Agopeed-extension&type=repositories)
 * [aria2](https://aria2.github.io/) - Terminal Download Manager / [Screenshot](https://i.ibb.co/SmsxmW3/3e213c54b148.png) / [GitHub](https://github.com/aria2/aria2) / [Download Bot](https://github.com/gaowanliang/DownloadBot) / [GUI](https://github.com/persepolisdm/persepolis) / [Frontend](https://ariang.mayswind.net/) / [WebUI](https://github.com/ziahamza/webui-aria2) / [GUI](https://persepolisdm.github.io/)
 * [FDM](https://www.freedownloadmanager.org/) - Download Manager / [YTDL Addon](https://github.com/meowcateatrat/elephant) / [Note](https://pastebin.com/Vgwf3avH)
-* [IDM](http://internetdownloadmanager.com/) / [Premium](https://rentry.co/FMHYBase64#idm) / [Trial Reset](https://github.com/J2TeaM/idm-trial-reset) / [Note](https://pastebin.com/7iq756yU) - Download Manager
+* [IDM](https://rentry.co/FMHYBase64#idm) - Download Manager
 * [pyLoad](https://pyload.net/) - Lightweight Download Manager
 * [File Centipede](https://filecxx.com/) - Upload / Download Manager
 * [DownThemAll](https://www.downthemall.org/) or [Turbo Download Manager](https://add0n.com/turbo-download-manager-v2.html) / [GitHub](https://github.com/inbasic/turbo-download-manager-v2/) - Download Management Extensions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed Official IDM link, Trial reset tool & note about it, renamed the crack link from Premium to IDM
## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After further testing the trial reset seems rather buggy, after each update the trial reset is needed again and now after a download is completed or randomly through out the day I've encountered a trial expired popup ~ but IDM continues to work & say trial mode. It's an annoyance so I'd rather use the patch & keygen from CracksURL instead. 
## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [x] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [x] I have made sure to [search](https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page) before making any changes. 
- [x] My code follows the code style of this project.
