### PR TITLE
Added Salwyrr client and a way to still use ofline(cracked accounts)

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -636,6 +636,7 @@
 * ⭐ **[Pojav](https://pojavlauncherteam.github.io/)** - Java Edition for Android / iOS / Requires Legit Copy
 * [MC Version Launcher](https://github.com/MCMrARM/mc-w10-version-launcher) - Multi-Version Launcher
 * [CheatBreaker](https://cheatbreaker.net/) - Anti-Cheat / FPS Boost / [GitHub](https://github.com/CheatBreakerNet)
+* [Salwyrr Client](https://www.salwyrr.com/) / [How To Crack](https://pastebin.com/ggcB7RNi)
 
 [UltimMC](https://github.com/UltimMC/Launcher), [MultiMC](https://multimc.org/), [Legacy Launcher](https://tlaun.ch/) [2](https://lln4.ru/en), [HMCL](https://github.com/HMCL-dev/HMCL) / [2](https://hmcl.huangyuhui.net/), [TechnicPack](https://www.technicpack.net/), [LabyMod](https://www.labymod.net/), [Crystal Launcher](https://crystal-launcher.net/), [GDLauncher](https://gdlauncher.com/), [X Minecraft Launcher](https://xmcl.app/)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added Salwyrr Client which was a high quaily cracked minecraft client however recently they removed offline(cracked accounts) so i added a pastebin explaining how to do that.

## Context
This change is required as there isn't many hight quilaiy clients on fmhy plus this client has unquie features that the others don't for example it was the abilty to use replay mod but it's in first person while still showing your inventory.

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [ x] I have made sure to [search](https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page) before making any changes. 
- [ x] My code follows the code style of this project.
