### PR TITLE
Reveddit and Uneddit are not working anymore

### DIFF
--- a/Social-Media-Tools.md
+++ b/Social-Media-Tools.md
@@ -232,7 +232,7 @@
 
 * ⭐ **[TheGigaBrain](https://thegigabrain.com/)**, [New PullPush](https://search-new.pullpush.io/) / [2](https://search.pullpush.io/), [Redditle](https://redditle.com/), [Reddit CSE](https://cse.google.com/cse?cx=016649841759798530173:rk2ezolwnw0) / [2](https://cse.google.com/cse?cx=007749065626525752968:qh5bqebwi30), [Samac](https://samac.io/), [ihsoyct](https://ihsoyct.github.io/index.html) or [Better Reddit Search](https://betterredditsearch.web.app/) - Reddit Search Engines
 * ⭐ **[RedditRepostSleuth](https://www.repostsleuth.com/)** - Reverse Post / Image Search
-* ⭐ **[Reveddit](https://www.reveddit.com/)** or [Unedit](https://denvercoder1.github.io/unedit-for-reddit/) - View Deleted Reddit Posts
+* ⭐ **[Undelete](https://undelete.pullpush.io/)** - View Deleted Reddit Posts
 * [ReSavr](https://www.resavr.com/) or [Comment History](https://academictorrents.com/details/89d24ff9d5fbc1efcdaf9d7689d72b7548f699fc) - Reddit Comment Archives
 * [RSOG](https://www.rsog.org/) - Reddit Search on Google / [Userscript](https://greasyfork.org/en/scripts/462356)
 * [Expanse](https://github.com/jc9108/expanse), [redarcs](https://the-eye.eu/redarcs/), [Rareddit](https://www.rareddit.com/) or [Reddit Archive](https://www.redditarchive.com/) - Reddit Post Archive Tools / [Note](https://ibb.co/R9jC5bk)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed Reveddit and Unedit links.
Changed to https://undelete.pullpush.io/

It doesn't have any relation with the undelete subreddit (https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. The lack of consistency of the megathread/wiki
## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [XXXXX ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [X ] I have made sure to [search](https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page) before making any changes. 
- [X ] My code follows the code style of this project.
