### PR TITLE
Added Bitwarden Emergency Kit

### DIFF
--- a/Internet-Tools.md
+++ b/Internet-Tools.md
@@ -54,7 +54,7 @@
 ## ▷ Password Managers
 
 * ⭐ **[KeePass XC](https://keepassxc.org/)**, [2](https://keepass.info/) - [Ports](https://keepass.info/download.html) / [Plugins](https://keepass.info/plugins.html) / [Read-Only Functionality](https://subdavis.com/Tusk/) / [CLI](https://github.com/rebkwok/kpcli)
-* ⭐ **[Bitwarden](https://bitwarden.com/)** - [bitwarden_gcloud](https://github.com/dadatuputi/bitwarden_gcloud) / [GUI](https://github.com/Sife-ops/dmenu_bw)
+* ⭐ **[Bitwarden](https://bitwarden.com/)** - [bitwarden_gcloud](https://github.com/dadatuputi/bitwarden_gcloud) / [GUI](https://github.com/Sife-ops/dmenu_bw) / [Emergency Kit](https://github.com/DevShubam/emergency-kits/blob/main/bitwarden.md)
 * [Proton Pass](https://proton.me/pass)
 * [TeamPass](https://teampass.net/) - Collaborative Password Manager
 * [Password Safe](https://www.pwsafe.org/) or [KDE Wallet Manager](https://userbase.kde.org/KDE_Wallet_Manager) - Password-Managing Software


### PR DESCRIPTION
I made a bitwarden emergency kit, so people can have a safe printout of their account details (similar to 1Password/Password Bits Emergency kit) Since we have bitwarden starred, i figured it'd be worth adding

soon ill also turn it into a pdf so it's easier for people to actually use


## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [ x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [ x] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [ x] I have made sure to [search](https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page) before making any changes. 
- [ x] My code follows the code style of this project.
