### PR TITLE
Update EDUPiracyGuide.md

### DIFF
--- a/EDUPiracyGuide.md
+++ b/EDUPiracyGuide.md
@@ -667,8 +667,8 @@
 * ⭐ **[Ptable](https://ptable.com/)** - Interactive Table
 * ⭐ **[Images-of-elements](https://images-of-elements.com/)** - Element Images
 * ⭐ **[periodic-table.org](https://www.periodic-table.org/)** or **[Material Properties](https://material-properties.org/)** - Elements Learning Resources
-* [Atomic](https://play.google.com/store/apps/details?id=com.jlindemann.science) - Mobile App
 * [Graph Overflow](https://graphoverflow.com/graphs/3d-periodic-table.html) or [3D Periodic Table](https://artsexperiments.withgoogle.com/periodic-table/) - 3D Visualizations of Atoms
+* [Atomic](https://play.google.com/store/apps/details?id=com.jlindemann.science) - Mobile App
 * [The Periodic Table Of Elements](https://periodictableofchemicalelements.com/) - Interactive Table
 * [periodic-table.io](https://periodic-table.io/) - Interactive Table
 * [Periodic Table App](https://periodictableapp.com/) - Interactive Table

--- a/EDUPiracyGuide.md
+++ b/EDUPiracyGuide.md
@@ -567,7 +567,6 @@
 ## ▷ Chemistry
 
 * 🌐 **[Wolfram Alpha Chemistry](https://wolframalpha.com/examples/science-and-technology/chemistry)** - Chemistry Calculators / Tools
-* ↪️ **[Periodic Table Of Elements](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_periodic_tables)** / [App](https://play.google.com/store/apps/details?id=com.jlindemann.science)
 * ⭐ **[Lab Safety Guide / Intro](https://labmode.co.uk/)**
 * ⭐ **[LibreTexts Chemistry](https://chem.libretexts.org)** - Chemistry Texts
 * ⭐ **[Internet Chemistry](https://www.internetchemistry.com/search.php)** - Search Index
@@ -663,18 +662,17 @@
 
 ***
 
-## ▷ Periodic Tables
+## ▷ Periodic Tables / Elements
 
 * ⭐ **[Ptable](https://ptable.com/)** - Interactive Table
+* ⭐ **[Images-of-elements](https://images-of-elements.com/)** - Element Images
+* ⭐ **[periodic-table.org](https://www.periodic-table.org/)** or **[Material Properties](https://material-properties.org/)** - Elements Learning Resources
+* [Atomic](https://play.google.com/store/apps/details?id=com.jlindemann.science) - Mobile App
+* [Graph Overflow](https://graphoverflow.com/graphs/3d-periodic-table.html) or [3D Periodic Table](https://artsexperiments.withgoogle.com/periodic-table/) - 3D Visualizations of Atoms
 * [The Periodic Table Of Elements](https://periodictableofchemicalelements.com/) - Interactive Table
-* [Periodic Table](https://periodic-table.io/) - Interactive Table
-* [Images-Of-Elements](https://images-of-elements.com/) - Interactive Table
-* [Graph Overflow](https://graphoverflow.com/graphs/3d-periodic-table.html) - Interactive Table
-* [3D Periodic Table](https://artsexperiments.withgoogle.com/periodic-table/) - Interactive Table
-* [PeriodicTableApp](https://periodictableapp.com/) - Interactive Table
-* [Periodic Table](https://www.periodic-table.org/) - Interactive Table
+* [periodic-table.io](https://periodic-table.io/) - Interactive Table
+* [Periodic Table App](https://periodictableapp.com/) - Interactive Table
 * [WebElements](https://www.webelements.com) - Interactive Table
-* [Elements Database](http://www.elementsdatabase.com/) - Interactive Table
 
 ***
 

--- a/EDUPiracyGuide.md
+++ b/EDUPiracyGuide.md
@@ -666,9 +666,9 @@
 
 * ⭐ **[Ptable](https://ptable.com/)** - Interactive Table
 * ⭐ **[Images-of-elements](https://images-of-elements.com/)** - Element Images
-* ⭐ **[periodic-table.org](https://www.periodic-table.org/)** or **[Material Properties](https://material-properties.org/)** - Elements Learning Resources
+* ⭐ **[periodic-table.org](https://www.periodic-table.org/)** or **[Material Properties](https://material-properties.org/)** - Material / Element Learning Resources
 * [Graph Overflow](https://graphoverflow.com/graphs/3d-periodic-table.html) or [3D Periodic Table](https://artsexperiments.withgoogle.com/periodic-table/) - 3D Visualizations of Atoms
-* [Atomic](https://play.google.com/store/apps/details?id=com.jlindemann.science) - Mobile App
+* [Atomic](https://play.google.com/store/apps/details?id=com.jlindemann.science) - Periodic Table Mobile App
 * [The Periodic Table Of Elements](https://periodictableofchemicalelements.com/) - Interactive Table
 * [periodic-table.io](https://periodic-table.io/) - Interactive Table
 * [Periodic Table App](https://periodictableapp.com/) - Interactive Table


### PR DESCRIPTION
- Tidied up, adding tags, and fixed titles.
- Renamed to "Periodic Tables / Elements". Fits better considering the new links.
- Removals:
	- dead redirect.
	- [Elements Database](http://www.elementsdatabase.com/) - dead.
- New Stars:
	- Images-of-elements - good source of images for each element. if there is no available image, it explains why, unlike other sites that could give fake images. ([example](https://periodictable.com/Items/087.4/index.html))
	- periodic-table.org & Material Properties - both seem like good resources for learning everything about atoms, elements, and stuff on a subatomic level.