### PR TITLE
Update VideoPiracyGuide.md for cached domains of Rive

### DIFF
--- a/VideoPiracyGuide.md
+++ b/VideoPiracyGuide.md
@@ -17,7 +17,7 @@
 * ⭐ **[KipFlix](https://kipflix.vercel.app/)** - Movies / TV / Anime / 1080p / [Discord](https://discord.gg/tDKYeh9eQn)
 * ⭐ **[NunFlix](https://nunflix.com/)** - Movies / TV / Anime / 4K / 1080p / [Discord](https://discord.gg/CXVyfhgn26)
 * ⭐ **[VidPlay](https://vidplay.org/)** - Movies / TV / Anime / 1080p / Ad-Free / [Note](https://pastebin.com/kXrVBceh)
-* ⭐ **[Rive](https://rivestream.vercel.app/)**, [2](https://rivestream.xyz/), [3](https://cinemaos-v2.vercel.app/) - Movies / TV / Anime / 4K / 1080p / Ad-Free / [GitHub](https://github.com/Developabile/rive-next) / [Status](https://github.com/Developabile/rive-next/blob/dev/Domains.md) / [Discord](https://discord.gg/6xJmJja8fV)
+* ⭐ **[Rive](https://rivestream.live/)**, [2](https://rivestream.netlify.app/) , [3](https://rivestream.xyz/), [4](https://cinemaos-v2.vercel.app/) - Movies / TV / Anime / 4K / 1080p / Ad-Free / [GitHub](https://github.com/Developabile/rive-next) / [Status](https://github.com/Developabile/rive-next/blob/dev/Domains.md) / [Discord](https://discord.gg/6xJmJja8fV)
 * [Streaming CSE](https://cse.google.com/cse?cx=006516753008110874046:cfdhwy9o57g##gsc.tab=0), [2](https://cse.google.com/cse?cx=006516753008110874046:o0mf6t-ugea##gsc.tab=0), [3](https://cse.google.com/cse?cx=98916addbaef8b4b6), [4](https://cse.google.com/cse?cx=0199ade0b25835f2e) - Multi-Site Search
 * [WatchingZone](https://www.watching.zone/) - Movies / TV / Anime / 1080p
 * [PrimeWire](https://www.primewire.tf/) - Movies / TV / Anime / 1080p


### PR DESCRIPTION
## Description
Added Two domains(from the official Rive project) for Rive
1. https://rivestream.live
2. https://rivestream.netlify.app

for authenticity check [Domains.md](https://github.com/Developabile/rive-next/blob/dev/Domains.md)

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `https://rivestream.live` domain results in fast page speeds and fast ad-free streaming.
It's using Cloudflare for both frontend and backend, all cached. so fast delivery
As `https://rivestream.live` is using `https://rivestream.vercel.app` under the hood so replaced the `vercel` deployment.

The `rivestream.netlify.app` uses netlify cdn for optimized delivery. It uses different medium to connect to the same backend for optimized cached traffic. It's using different instance of scrapper for faster ad-free streaming.

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [x] I have made sure to [search](https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page) before making any changes. 
- [x] My code follows the code style of this project.
