### PR TITLE
Added Wallpaper Tools section

### DIFF
--- a/System-Tools.md
+++ b/System-Tools.md
@@ -476,10 +476,38 @@
 
 ## ▷ Wallpapers
 
-* ⭐ **[Wallpaper Engine](https://rentry.co/FMHYBase64#wallpaper-engine)** - Wallpaper Manager / [PKG to Zip](https://github.com/TheRioMiner/Wallpaper-Engine-Pkg-to-Zip) / [Collections](https://www.wallpaperengine.space/collections), [2](https://steamcommunity.com/sharedfiles/filedetails/?id=2801058904) / [Workshop DL](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_steam_workshop_downloaders)
-* ⭐ **[wallhaven](https://wallhaven.cc/)** / [Downloader](https://github.com/eramdam/WallbaseDirectDownloader) - Wallpapers
-* ⭐ **[Wallpaper Abyss](https://wall.alphacoders.com/)** - Wallpapers
+* ⭐ **[wallhaven](https://wallhaven.cc/)** / [Downloader](https://github.com/eramdam/WallbaseDirectDownloader)
+* ⭐ **[Wallpaper Abyss](https://wall.alphacoders.com/)**
 * ⭐ **[Studio Ghibli Wallpapers](https://www.ghibli.jp/info/013772)** or [Ghibli Upscaled](https://rentry.co/FMHYBase64#ghibli-upscaled)
+* [Scenic Illustrations](https://www.pixeltrue.com/scenic-illustrations) - Landscape Wallpapers
+* [CoolBackgrounds](https://coolbackgrounds.io/) or [wallup](https://wallup.net/) - Customizable Wallpapers
+* [Simple Desktops](https://simpledesktops.com/), [Positron Dream](https://www.positrondream.com/) or [SetAsWall](https://www.setaswall.com/) - Minimalistic Wallpapers
+* [/r/LivingBackgrounds](https://reddit.com/r/LivingBackgrounds), [Lively](https://www.rocksdanister.com/lively/), [WALLegend](https://wallegend.net/en/) or [MoeWalls](https://moewalls.com/) - Animated Wallpapers
+* [DualMonitorBackgrounds](https://www.dualmonitorbackgrounds.com/) or [WallpaperFusion](https://www.wallpaperfusion.com/) - Dual Monitor Wallpapers
+* [Screencaps](https://screencaps.us/) or [shot.cafe](https://shot.cafe/) - Movie / TV Wallpapers
+* [Anime Pictures](https://anime-pictures.net/), [N0va](https://n0vadp.hoyoverse.com), [Anime_WallpapersHD](https://t.me/Anime_WallpapersHD/), [WallpaperWaifu](https://wallpaperwaifu.com/) or [MyLiveWallpapers](https://mylivewallpapers.com/) - Anime Wallpapers
+* [Dracula Wallpapers](https://draculatheme.com/wallpaper) - Dracula Wallpapers
+* [WallpaperHub](https://www.wallpaperhub.app/) - Windows Wallpapers
+* [Mac Walls](https://goo.gl/photos/HjY1hmo6p3jfFz8a7), [2](https://photos.google.com/share/AF1QipNNQyeVrqxBdNmBkq9ILswizuj-RYJFNt5GlxJZ90Y6hx0okrVSLKSnmFFbX7j5Mg?key=RV8tSXVJVGdfS1RIQUI0Q3RZZVhlTmw0WmhFZ2V3) - Mac Wallpapers
+* [Wallpapers.com](https://wallpapers.com/)
+* [WallpaperSafari](https://wallpapersafari.com/)
+* [WallpapersDen](https://wallpapersden.com/)
+* [WallpaperCave](https://wallpapercave.com/)
+* [Wallpaper Tip](https://wallpapertip.com/)
+* [4KWallpapers](https://4kwallpapers.com/)
+* [WallsPic](https://wallspic.com/)
+* [WallpaperFlare](https://www.wallpaperflare.com/)
+* [HDQwalls](https://hdqwalls.com/)
+* [UHD Wallpaper](https://www.uhdpaper.com/) - Wallpapers
+* [WallpapersCraft](https://wallpaperscraft.com/)
+* [wallha](https://wallha.com/)
+* [G_Walls](https://t.me/G_Walls) - TG Wallpapers
+* [pengwyn](https://t.me/pengwyn) - TG Wallpapers
+
+***
+
+## ▷ Wallpaper Tools
+* ⭐ **[Wallpaper Engine](https://rentry.co/FMHYBase64#wallpaper-engine)** - Wallpaper Manager / [PKG to Zip](https://github.com/TheRioMiner/Wallpaper-Engine-Pkg-to-Zip) / [Collections](https://www.wallpaperengine.space/collections), [2](https://steamcommunity.com/sharedfiles/filedetails/?id=2801058904) / [Workshop DL](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_steam_workshop_downloaders)
 * ⭐ **[LWP](https://github.com/jszczerbinsky/lwp)** - Move Wallpapers with Cursor
 * [ScreenPlay](https://screen-play.app/) - Wallpaper Manager
 * [backiee](https://apps.microsoft.com/store/detail/backiee-wallpaper-studio-10/9WZDNCRFHZCD) - Wallpaper Manager
@@ -488,28 +516,3 @@
 * [Faerber](https://farbenfroh.io/) - Edit Wallpaper to Match Color Scheme
 * [Background Switcher](https://johnsad.ventures/software/backgroundswitcher/) - Multi-Host Wallpaper Switcher
 * [AutoWall](https://github.com/SegoCode/AutoWall) - Turn Videos / GIFs to Live Wallpapers
-* [Scenic Illustrations](https://www.pixeltrue.com/scenic-illustrations) - Landscape Wallpapers
-* [CoolBackgrounds](https://coolbackgrounds.io/) or [wallup](https://wallup.net/) - Customizable Wallpapers
-* [Simple Desktops](https://simpledesktops.com/), [Positron Dream](https://www.positrondream.com/) or [SetAsWall](https://www.setaswall.com/) - Minimalistic Wallpapers
-* [/r/LivingBackgrounds](https://reddit.com/r/LivingBackgrounds), [Lively](https://www.rocksdanister.com/lively/), [WALLegend](https://wallegend.net/en/) or [MoeWalls](https://moewalls.com/) - Animated Wallpapers
-* [DualMonitorBackgrounds](https://www.dualmonitorbackgrounds.com/) or [WallpaperFusion](https://www.wallpaperfusion.com/) - Dual Monitor Wallpapers
-* [Screencaps](https://screencaps.us/) or [shot.cafe](https://shot.cafe/) - Movie / TV Wallpapers
-* [Xbox Wallpapers](https://www.xbox.com/en-us/wallpapers/) - Game Wallpapers
-* [Anime Pictures](https://anime-pictures.net/), [N0va](https://n0vadp.hoyoverse.com), [Anime_WallpapersHD](https://t.me/Anime_WallpapersHD/), [WallpaperWaifu](https://wallpaperwaifu.com/) or [MyLiveWallpapers](https://mylivewallpapers.com/) - Anime Wallpapers
-* [Dracula Wallpapers](https://draculatheme.com/wallpaper) - Dracula Wallpapers
-* [WallpaperHub](https://www.wallpaperhub.app/) - Windows Wallpapers
-* [Mac Walls](https://goo.gl/photos/HjY1hmo6p3jfFz8a7), [2](https://photos.google.com/share/AF1QipNNQyeVrqxBdNmBkq9ILswizuj-RYJFNt5GlxJZ90Y6hx0okrVSLKSnmFFbX7j5Mg?key=RV8tSXVJVGdfS1RIQUI0Q3RZZVhlTmw0WmhFZ2V3) - Mac Wallpapers
-* [Wallpapers.com](https://wallpapers.com/) - Wallpapers
-* [WallpaperSafari](https://wallpapersafari.com/) - Wallpapers
-* [WallpapersDen](https://wallpapersden.com/) - Wallpapers
-* [WallpaperCave](https://wallpapercave.com/) - Wallpapers
-* [Wallpaper Tip](https://wallpapertip.com/) - Wallpapers
-* [4KWallpapers](https://4kwallpapers.com/) - Wallpapers
-* [WallsPic](https://wallspic.com/) - Wallpapers
-* [WallpaperFlare](https://www.wallpaperflare.com/) - Wallpapers
-* [HDQwalls](https://hdqwalls.com/) - Wallpapers
-* [UHD Wallpaper](https://www.uhdpaper.com/) - Wallpapers
-* [WallpapersCraft](https://wallpaperscraft.com/) - Wallpapers
-* [wallha](https://wallha.com/) - Wallpapers
-* [G_Walls](https://t.me/G_Walls) - TG Wallpapers
-* [pengwyn](https://t.me/pengwyn) - TG Wallpapers

--- a/single-page
+++ b/single-page
@@ -6473,10 +6473,38 @@ https://aniwow.in/ has only dubs though
 
 ## ▷ Wallpapers
 
-* ⭐ **[Wallpaper Engine](https://rentry.co/FMHYBase64#wallpaper-engine)** - Wallpaper Manager / [PKG to Zip](https://github.com/TheRioMiner/Wallpaper-Engine-Pkg-to-Zip) / [Collections](https://www.wallpaperengine.space/collections), [2](https://steamcommunity.com/sharedfiles/filedetails/?id=2801058904) / [Workshop DL](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_steam_workshop_downloaders)
-* ⭐ **[wallhaven](https://wallhaven.cc/)** / [Downloader](https://github.com/eramdam/WallbaseDirectDownloader) - Wallpapers
-* ⭐ **[Wallpaper Abyss](https://wall.alphacoders.com/)** - Wallpapers
+* ⭐ **[wallhaven](https://wallhaven.cc/)** / [Downloader](https://github.com/eramdam/WallbaseDirectDownloader)
+* ⭐ **[Wallpaper Abyss](https://wall.alphacoders.com/)**
 * ⭐ **[Studio Ghibli Wallpapers](https://www.ghibli.jp/info/013772)** or [Ghibli Upscaled](https://rentry.co/FMHYBase64#ghibli-upscaled)
+* [Scenic Illustrations](https://www.pixeltrue.com/scenic-illustrations) - Landscape Wallpapers
+* [CoolBackgrounds](https://coolbackgrounds.io/) or [wallup](https://wallup.net/) - Customizable Wallpapers
+* [Simple Desktops](https://simpledesktops.com/), [Positron Dream](https://www.positrondream.com/) or [SetAsWall](https://www.setaswall.com/) - Minimalistic Wallpapers
+* [/r/LivingBackgrounds](https://reddit.com/r/LivingBackgrounds), [Lively](https://www.rocksdanister.com/lively/), [WALLegend](https://wallegend.net/en/) or [MoeWalls](https://moewalls.com/) - Animated Wallpapers
+* [DualMonitorBackgrounds](https://www.dualmonitorbackgrounds.com/) or [WallpaperFusion](https://www.wallpaperfusion.com/) - Dual Monitor Wallpapers
+* [Screencaps](https://screencaps.us/) or [shot.cafe](https://shot.cafe/) - Movie / TV Wallpapers
+* [Anime Pictures](https://anime-pictures.net/), [N0va](https://n0vadp.hoyoverse.com), [Anime_WallpapersHD](https://t.me/Anime_WallpapersHD/), [WallpaperWaifu](https://wallpaperwaifu.com/) or [MyLiveWallpapers](https://mylivewallpapers.com/) - Anime Wallpapers
+* [Dracula Wallpapers](https://draculatheme.com/wallpaper) - Dracula Wallpapers
+* [WallpaperHub](https://www.wallpaperhub.app/) - Windows Wallpapers
+* [Mac Walls](https://goo.gl/photos/HjY1hmo6p3jfFz8a7), [2](https://photos.google.com/share/AF1QipNNQyeVrqxBdNmBkq9ILswizuj-RYJFNt5GlxJZ90Y6hx0okrVSLKSnmFFbX7j5Mg?key=RV8tSXVJVGdfS1RIQUI0Q3RZZVhlTmw0WmhFZ2V3) - Mac Wallpapers
+* [Wallpapers.com](https://wallpapers.com/)
+* [WallpaperSafari](https://wallpapersafari.com/)
+* [WallpapersDen](https://wallpapersden.com/)
+* [WallpaperCave](https://wallpapercave.com/)
+* [Wallpaper Tip](https://wallpapertip.com/)
+* [4KWallpapers](https://4kwallpapers.com/)
+* [WallsPic](https://wallspic.com/)
+* [WallpaperFlare](https://www.wallpaperflare.com/)
+* [HDQwalls](https://hdqwalls.com/)
+* [UHD Wallpaper](https://www.uhdpaper.com/) - Wallpapers
+* [WallpapersCraft](https://wallpaperscraft.com/)
+* [wallha](https://wallha.com/)
+* [G_Walls](https://t.me/G_Walls) - TG Wallpapers
+* [pengwyn](https://t.me/pengwyn) - TG Wallpapers
+
+***
+
+## ▷ Wallpaper Tools
+* ⭐ **[Wallpaper Engine](https://rentry.co/FMHYBase64#wallpaper-engine)** - Wallpaper Manager / [PKG to Zip](https://github.com/TheRioMiner/Wallpaper-Engine-Pkg-to-Zip) / [Collections](https://www.wallpaperengine.space/collections), [2](https://steamcommunity.com/sharedfiles/filedetails/?id=2801058904) / [Workshop DL](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_steam_workshop_downloaders)
 * ⭐ **[LWP](https://github.com/jszczerbinsky/lwp)** - Move Wallpapers with Cursor
 * [ScreenPlay](https://screen-play.app/) - Wallpaper Manager
 * [backiee](https://apps.microsoft.com/store/detail/backiee-wallpaper-studio-10/9WZDNCRFHZCD) - Wallpaper Manager
@@ -6485,31 +6513,6 @@ https://aniwow.in/ has only dubs though
 * [Faerber](https://farbenfroh.io/) - Edit Wallpaper to Match Color Scheme
 * [Background Switcher](https://johnsad.ventures/software/backgroundswitcher/) - Multi-Host Wallpaper Switcher
 * [AutoWall](https://github.com/SegoCode/AutoWall) - Turn Videos / GIFs to Live Wallpapers
-* [Scenic Illustrations](https://www.pixeltrue.com/scenic-illustrations) - Landscape Wallpapers
-* [CoolBackgrounds](https://coolbackgrounds.io/) or [wallup](https://wallup.net/) - Customizable Wallpapers
-* [Simple Desktops](https://simpledesktops.com/), [Positron Dream](https://www.positrondream.com/) or [SetAsWall](https://www.setaswall.com/) - Minimalistic Wallpapers
-* [/r/LivingBackgrounds](https://reddit.com/r/LivingBackgrounds), [Lively](https://www.rocksdanister.com/lively/), [WALLegend](https://wallegend.net/en/) or [MoeWalls](https://moewalls.com/) - Animated Wallpapers
-* [DualMonitorBackgrounds](https://www.dualmonitorbackgrounds.com/) or [WallpaperFusion](https://www.wallpaperfusion.com/) - Dual Monitor Wallpapers
-* [Screencaps](https://screencaps.us/) or [shot.cafe](https://shot.cafe/) - Movie / TV Wallpapers
-* [Xbox Wallpapers](https://www.xbox.com/en-us/wallpapers/) - Game Wallpapers
-* [Anime Pictures](https://anime-pictures.net/), [N0va](https://n0vadp.hoyoverse.com), [Anime_WallpapersHD](https://t.me/Anime_WallpapersHD/), [WallpaperWaifu](https://wallpaperwaifu.com/) or [MyLiveWallpapers](https://mylivewallpapers.com/) - Anime Wallpapers
-* [Dracula Wallpapers](https://draculatheme.com/wallpaper) - Dracula Wallpapers
-* [WallpaperHub](https://www.wallpaperhub.app/) - Windows Wallpapers
-* [Mac Walls](https://goo.gl/photos/HjY1hmo6p3jfFz8a7), [2](https://photos.google.com/share/AF1QipNNQyeVrqxBdNmBkq9ILswizuj-RYJFNt5GlxJZ90Y6hx0okrVSLKSnmFFbX7j5Mg?key=RV8tSXVJVGdfS1RIQUI0Q3RZZVhlTmw0WmhFZ2V3) - Mac Wallpapers
-* [Wallpapers.com](https://wallpapers.com/) - Wallpapers
-* [WallpaperSafari](https://wallpapersafari.com/) - Wallpapers
-* [WallpapersDen](https://wallpapersden.com/) - Wallpapers
-* [WallpaperCave](https://wallpapercave.com/) - Wallpapers
-* [Wallpaper Tip](https://wallpapertip.com/) - Wallpapers
-* [4KWallpapers](https://4kwallpapers.com/) - Wallpapers
-* [WallsPic](https://wallspic.com/) - Wallpapers
-* [WallpaperFlare](https://www.wallpaperflare.com/) - Wallpapers
-* [HDQwalls](https://hdqwalls.com/) - Wallpapers
-* [UHD Wallpaper](https://www.uhdpaper.com/) - Wallpapers
-* [WallpapersCraft](https://wallpaperscraft.com/) - Wallpapers
-* [wallha](https://wallha.com/) - Wallpapers
-* [G_Walls](https://t.me/G_Walls) - TG Wallpapers
-* [pengwyn](https://t.me/pengwyn) - TG Wallpapers
 # -> ***Beginners Guide to Piracy*** <-
 
 ***


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Made new wallpaper tools section and moved all the relevant tools from Wallpapers section.

## Context
<!--- Why is this change required? What problem does it solve? -->
Tools were causing confusions when kept between wallpaper discovery sites. they need a separate section imo.
Also removed [Xbox Wallpapers](https://www.xbox.com/en-us/wallpapers/) for now as the page is getting a makeover. add when its back
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [X] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [X] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [X] I have made sure to [search](https://raw.githubusercontent.com/fmhy/FMHYedit/main/single-page) before making any changes. 
- [X] My code follows the code style of this project.
