### PR TITLE
Fixing picom description in linuxguide.md

### DIFF
--- a/docs/linuxguide.md
+++ b/docs/linuxguide.md
@@ -66,7 +66,7 @@
 * [Nanobench](https://github.com/andreas-abel/nanoBench) - CPU Microbenchmark / [Documentation](https://nanobench.ankerl.com/)
 * [ScanMem](https://github.com/scanmem/scanmem) - Memory Scanner / Debugger
 * [pacwall](https://github.com/Kharacternyk/pacwall) - Live Wallpaper Dependency Graph / Package Status
-* [picom](https://github.com/yshui/picom) - Wayland Compositors
+* [picom](https://github.com/yshui/picom) - Compositor for standalone X11 Window Managers
 * [keyd](https://github.com/rvaiya/keyd) or [xremap](https://github.com/k0kubun/xremap) - Keyboard Remapping
 * [LAN Mouse](https://github.com/feschber/lan-mouse) - Mouse & Keyboard Sharing
 * [Input Leap](https://github.com/input-leap/input-leap) - Multi-Computer Control


### PR DESCRIPTION
## Description
Changing [picom](https://github.com/yshui/picom) description.

## Context
A change i forgot to make in a [previous PR](https://github.com/fmhy/FMHYedit/pull/2176) that got committed, a copy of the explanation of said PR follows bellow as it also explains this change.

[Picom](https://github.com/yshui/picom) is a compositor for X.Org/X11, not for Wayland. That word has different meanings when it comes to those display protocols. On the former it refers to a software to be (optionally) used alongside a window manager to add some visual effects to it, like window animations, blur, rounded corners and so on. On the latter it refers to the window manger manager itself, which may or may not have said visual effects built directly into it.

## Types of changes
- [ ] Bad / Deleted sites removal
- [X] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [XI have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [X] I have made sure to [search](https://feedback.tasky.workers.dev/single-page) before making any changes. 
- [X] My code follows the code style of this project.
