### PR TITLE
Kawaii mode easy access

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,12 @@ onMounted(() => {
       img.src = '/logo-uwu.svg'
     })
   }
+  const resetKawaii = () => {
+    const images = document.querySelectorAll('.VPImage.image-src')
+    images.forEach((img) => {
+      img.src = '/test.png'
+    })
+  }
   if (kawaii === 'true') {
     try {
       localStorage.setItem('uwu', true)
@@ -69,12 +75,33 @@ onMounted(() => {
     try {
       localStorage.removeItem('uwu', false)
     } catch (err) {}
-    const images = document.querySelectorAll('.VPImage.image-src')
-    images.forEach((img) => {
-      img.src = '/test.png'
-    })
+    resetKawaii()
   } else if (preferredKawaii) {
     setKawaii()
+  }
+
+  let clickCount = 0;
+  const heroImage = document.querySelector('.VPImage.image-src');
+  
+  const handleClick = () => {
+    clickCount += 1;
+    if (clickCount === 5) {
+      const isKawaii = localStorage.getItem('uwu') === 'true';
+      if (isKawaii) {
+        localStorage.removeItem('uwu');
+        resetKawaii();
+        console.log('uwu mode disabled.');
+      } else {
+        localStorage.setItem('uwu', true);
+        setKawaii();
+        console.log('uwu mode enabled after 5 clicks.');
+      }
+      clickCount = 0;
+    }
+  };
+
+  if (heroImage) {
+    heroImage.addEventListener('click', handleClick);
   }
 })
 </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a click listen event where if the header image is click 5 times, it changes into Kawaii mode.

## Context
This makes it easier for the easter egg to be accessed

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [x] I have made sure to [search](https://feedback.tasky.workers.dev/single-page) before making any changes. 
- [x] My code follows the code style of this project.
