### PR TITLE
Improve links for Stremio

### DIFF
--- a/docs/android-iosguide.md
+++ b/docs/android-iosguide.md
@@ -879,7 +879,7 @@
 # ► Android Streaming
 
 * ↪️ **[Video Players](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/storage#wiki_android_video_players)**
-* ⭐ **[Stremio](https://www.stremio.com/)** - Torrent Streaming / [Addons](https://stremio-addons.netlify.app/) / Chromecast / Use [VPN](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/adblock-vpn-privacy#wiki_vpn_guide)
+* ⭐ **[Stremio](https://www.stremio.com/)** - Torrent Streaming / [/r/StremioAddons](https://reddit.com/r/StremioAddons) / Use [VPN](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/adblock-vpn-privacy#wiki_vpn_guide)
 * ⭐ **[CloudStream](https://cloudstream-on-fleek-co.ipns.dweb.link/)** - Movies / TV / Anime
 * ⭐ **CloudStream Resources** - [Plugins](https://discord.com/invite/wpX5Rfcx87), [2](https://github.com/Rowdy-Avocado/Rowdycado-Extensions), [3](https://rentry.org/cs3-repos) / [Discord](https://discord.com/invite/5Hus6fM) / [Docs](https://recloudstream.github.io/csdocs/), [2](https://cloudstream.miraheze.org/wiki/Main_Page) / [GitHub](https://github.com/recloudstream/cloudstream)
 * ⭐ **[FlixQuest](https://flixquest.beamlak.dev/)** - Movies / TV / [GitHub](https://github.com/BeamlakAschalew/flixquest)
@@ -888,8 +888,8 @@
 * ⭐ **[HDO Box](https://rentry.co/FMHYBase64#hdo-box)** - Movies / TV / [Discord](https://discord.gg/VPRJVExUVD) / [Telegram](https://t.me/+Ywz5HnhvFHA3Zjk1) / [Warning](https://i.ibb.co/ZBy93sr/image.png)
 * ⭐ **[Kodi](https://kodi.tv/)** - [/r/Addons4Kodi](https://www.reddit.com/r/Addons4Kodi/) / [Tracker](https://kinkeadtech.com/best-kodi-streaming-addons/) / [Trending](https://kodiapps.com/addons-chart) / [Real-Debrid](https://real-debrid.com/)
 * ⭐ **[Syncler](https://syncler.net/)** - Movies / TV / [Providers](https://www.reddit.com/r/providers4syncler/)
-* ⭐ **[BubblesUPNP](https://play.google.com/store/apps/details?id=com.bubblesoft.android.bubbleupnp&gl=US)**, [DMS](https://github.com/anacrolix/dms) or [Macast](https://xfangfang.github.io/Macast/) - Media Servers / Chromecast
-* [PopcornTime](https://popcorn-time.site) / [GitHub](https://github.com/popcorn-official/popcorn-android) - Torrent Streaming / Chromecast / Use [VPN](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/adblock-vpn-privacy#wiki_vpn_guide)
+* ⭐ **[BubblesUPNP](https://play.google.com/store/apps/details?id=com.bubblesoft.android.bubbleupnp&gl=US)**, [DMS](https://github.com/anacrolix/dms) or [Macast](https://xfangfang.github.io/Macast/) - Media Servers
+* [PopcornTime](https://popcorn-time.site) / [GitHub](https://github.com/popcorn-official/popcorn-android) - Torrent Streaming / Use [VPN](https://www.reddit.com/r/FREEMEDIAHECKYEAH/wiki/adblock-vpn-privacy#wiki_vpn_guide)
 * [FilmPlus](https://filmplus.app/) - Movies / TV
 * [Vega App](https://github.com/Zenda-Cross/vega-app) - Movies / TV
 * [TeaTV](https://rentry.co/FMHYBase64#teatv) - Movies / TV
@@ -1227,7 +1227,7 @@
 
 # ► iOS Streaming
 
-* ⭐ **[Stremio](https://web.stremio.com/)** - Movies / TV / Anime / Use VPN / [Alt Method](https://files.catbox.moe/dins97.mp4)
+* ⭐ **[Stremio](https://web.stremio.com/)** - Movies / TV / Anime / [Guide](https://viren070.github.io/guides/stremio/guide?platform=web-ios)
 * ⭐ **[Streamer](https://github.com/StreamerApp/Streamer)** - Movies / TV
 * ⭐ **[Kodi](https://kodi.tv/)** - Movies / TV / Anime / [/r/Addons4Kodi](https://www.reddit.com/r/Addons4Kodi/) / [Tracker](https://kinkeadtech.com/best-kodi-streaming-addons/) / [Trending](https://kodiapps.com/addons-chart)
 * [Swiftfin](https://apps.apple.com/us/app/swiftfin/id1604098728) - Jellyfin Client

--- a/docs/beginners-guide.md
+++ b/docs/beginners-guide.md
@@ -185,7 +185,7 @@ Use this [browser extension](https://github.com/bpc-clone/bpc_updates/releases) 
 * **[APKMirror](https://www.apkmirror.com/)** - Untouched APKs
 * **[F-Droid](https://f-droid.org/)** - FOSS Android Apps
 * **[Android APK CSE](https://cse.google.com/cse?cx=e0d1769ccf74236e8) / [2](https://cse.google.com/cse?cx=73948689c2c206528) / [3](https://cse.google.com/cse?cx=a805854b6a196d6a6)** - Multi-site APK search
-* **[Stremio](https://www.stremio.com/)** - Video streaming app / Use VPN / [Guide](https://rentry.co/privatestremio)
+* **[Stremio](https://www.stremio.com/)** - Video streaming app / Use VPN / [Guide](https://viren070.github.io/guides/stremio/guide)
 * **[Patch Reddit Clients](https://docs.google.com/document/u/0/d/1wHvqQwCYdJrQg4BKlGIVDLksPN0KpOnJWniT6PbZSrI/mobilebasic)** - How To Patch 3rd Party Reddit Clients
 * **[ReVanced Manager](https://github.com/revanced/revanced-manager)** - Ad-Free YouTube, Reddit, X etc. Patcher / [Discord](https://discord.com/invite/rF2YcEjcrT) / [Guide](https://redd.it/xlcny9)
 * **[Complete Jailbreak Chart](https://ios.cfw.guide/)** - Jailbreaking info & tools

--- a/docs/videopiracyguide.md
+++ b/docs/videopiracyguide.md
@@ -677,7 +677,7 @@
 ## ▷ Stremio Tools
 
 * 🌐 **[Stremio Addons](https://stremio-addons.netlify.app/)** - Stremio Addons
-* [PrivateStremio](https://rentry.co/privatestremio) - Stremio Guide
+* [Viren070's Guides](viren070.github.io/guides/stremio/guide) - Stremio Guide
 * [Stremio Addon Manager](https://stremio-addon-manager.vercel.app/) - Addons Manager
 * [streamio-ffmpeg](https://github.com/streamio/streamio-ffmpeg) - ffmpeg Wrapper
 * [Stremio Simkl](https://simkl.com/apps/stremio/) - Stremio Simkl Addon


### PR DESCRIPTION
## Description
I have made a few changes, I will go through each below. However, the main change is the addition of [my guide for Stremio](https://guides.viren070.me/stremio/guide) and the removal of [PrivateStremio](https://rentry.co/privatestremio)

**android-iosguide.md**
- Under Android Streaming, I removed any Chromecast mentions from android streaming section.
- Link to r/StremioAddons instead of addons website. The addons website is pinned at this subreddit and more information can be found at this subreddit. 
- Under iOS streaming, I have replaced the current video guide for Stremio with my own guide. 
- I also removed the Use VPN warning in iOS streaming for Stremio.

**videopiracyguide.md**
- Replace PrivateStremio guide with my own guide.

**beginners-guide.md**
- Replace PrivateStremio guide with my own guide. 

## Context

I removed the Chromecast mentions because:
- This is the Android streaming section and there is a dedicated Smart TV section where you could add apps like Stremio.
- Although it seems that this section is for Android TV apps too so you could exclude this change. 
- With the release of the new Streamer device, you may also want to clarify the device you are referring to though I do agree that the Chromecast is the best choice for those outside the US. 
- However, for those in the US, the ONN 4K from Walmart provides much better value. 
- Due to this, I believe a single device should not be recommended here. 

The Use VPN warning was removed for iOS because:
- Torrent streaming is not possible on iOS without setting up the streaming service. The average user will never do this and instead use a debrid service. 
- To those who are setting up the streaming server on another device, they are likely to know what they are doing and that they will be torrenting.
- To the average user, it will be misleading as they may think they need a VPN to use Stremio on iOS when it is not the case. 
- I would suggest that you also replace the Use VPN warning on other mentions of Stremio with a Use Debrid service as for Stremio, you get a much better experience with a debrid service rather than a VPN.

I replaced the link to the stremio-addons website with /r/StremioAddons because: 
- The addons website is pinned in this subreddit 
- There are more posts that can help new users within this community. 
- The Kodi bullet point also links to /r/Addons4Kodi 
- Though now that I think about it, the stremio addons website has links to all the socials of the StremioAddons community (at the bottom of the page) so this change could be excluded. 

I have replaced the current iOS video guide because: 
- The video guide has an outdated UI of Stremio.
- There is a simpler method that requires no extra action compared to android apps. 
- The video does not mention any addons or the fact that torrent streaming is not possible
- The video does not mention that to be in a usable state, you would need a debrid service. (although it is shown through the [RD+] links, the average user will not notice this or realise that it is required) 

I have replaced the PrivateStremio guide because: 
- The method it uses to get Warp+ for free no longer works due to the GitHub repository being taken down (https://github.com/ALIILAPRO/warp-plus-cloudflare/)
- As a result, it is no longer viable through just the free version to stream torrents due to high data usage depending on content watched
- Method 1 simply showed you how to get a free VPN (and use it on unsupported devices) for torrent streaming. It is not exactly specific to Stremio.
- Method 2, while a great way of using stremio for free, is not the reason why stremio is so popular.  Users are expecting a simple setup and access to a large library of movies and shows, but stremio-gdrive is not the way to go about this.

The reason why I propose adding my own guide is because I believe it covers all the issues I have mentioned. It also still covers the stremio-gdrive addon and instructions for iOS devices too. I have used the following query string and value - ?platform=web-ios - for the link for the iOS guide. 

The site currently has a custom domain of https://guides.viren070.me but I have used the GitHub Pages default link of https://viren070.github.io/guides so that even if the custom domain expires (and I decide not to renew), the site remains usable. 

The website is built using [Docusaurus](https://docusaurus.io/) and the source code of the site is available at https://github.com/Viren070/guides

With all that being said, I hope my guide can be linked on this site to make it easy for people to use Stremio. 

## Types of changes

- [x] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [x] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [x] I have made sure to [search](https://feedback.tasky.workers.dev/single-page) before making any changes. 
- [x] My code follows the code style of this project.
