### PR TITLE
Get rid of same page listed twice in same section

### DIFF
--- a/docs/linuxguide.md
+++ b/docs/linuxguide.md
@@ -181,7 +181,6 @@
 * [KDE Applications](https://apps.kde.org/) - KDE Apps
 * [The Book of Secret Knowledge](https://github.com/trimstray/the-book-of-secret-knowledge)
 * [Ultimate Cheatsheet](https://gist.github.com/bgoonz/be5c5be77169ef333b431bc37d331176)
-* [ArchWiki List of Applications](https://wiki.archlinux.org/title/list_of_applications)
 * [LinuxAlt](https://www.linuxalt.com/)
 * [Plan9Port](https://9fans.github.io/plan9port/) / [GitHub](https://github.com/9fans/plan9port)
 * [tlanyan](https://itlanyan.com/)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The Arch Linux List of applications page was listed twice under slightly different names, though both served the same purpose for the section they were on.

## Context
It gets rid of one of two links to the same page.

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [x] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://rentry.co/Contrib-Guide).
- [x] I have made sure to [search](https://feedback.tasky.workers.dev/single-page) before making any changes. 
- [x] My code follows the code style of this project.