### PR TITLE
New: added sref-midjourney.com

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -345,6 +345,7 @@
 * [The Other](https://rentry.org/59xed3), [DummyLoRA](https://rentry.org/dummylora), [ezlora](https://rentry.org/ezlora), [Dreambooth](https://rentry.org/2chAI_LoRA_Dreambooth_guide_english), [ora_train](https://rentry.org/lora_train) - SD LoRA Guides
 * [SafeTensorsGuide](https://rentry.org/safetensorsguide) - How-to Convert .ckpt to .safetensors
 * [DummyControlNet](https://rentry.org/dummycontrolnet) - ControlNet Guide
+* [Midjourney Sref Library](https://sref-midjourney.com) - Collection of --sref codes for Midjourney
 
 ***
 


### PR DESCRIPTION
## Description

Added [sref-midjourney.com](https://sref-midjourney.com) to the Guides / Tools section for AI Images

## Context

Curated collection of Midjourney sref codes for styling images generated using Midjourney

## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
