### PR TITLE
Removed solidtorrents.to and bitsearch.to

### DIFF
--- a/docs/audiopiracyguide.md
+++ b/docs/audiopiracyguide.md
@@ -419,7 +419,6 @@
 * ⭐ **[Audio Torrent CSE](https://cse.google.com/cse?cx=006516753008110874046:v75cyb4ci55)** - Multi-Site Search
 * [DimeADozen](http://www.dimeadozen.org/) - MP3 / FLAC
 * [TheTradersDen](http://www.thetradersden.org/) - FLAC
-* [SolidTorrents](https://solidtorrents.to/) - MP3 / FLAC
 * [TPB Music](https://thepiratebay.org/search.php?q=top100:100) - MP3 / FLAC / **Avoid Software / Games**
 * [HQMusic](http://hqmusic.info/) - FLAC / Signup Required
 * [TheMixingBowl](https://themixingbowl.org/) - MP3 / Signup Required

--- a/docs/torrentpiracyguide.md
+++ b/docs/torrentpiracyguide.md
@@ -40,9 +40,7 @@
 * ⭐ **[BTDigg](https://btdig.com/index.htm)** - [.onion](http://btdigggink2pdqzqrik3blmqemsbntpzwxottujilcdjfz56jumzfsyd.onion/), [2](https://btdigggink2pdqzqrik3blmqemsbntpzwxottujilcdjfz56jumzfsyd.onion.ly/) / [i2p](http://btdigg.i2p/)
 * ⭐ **[snowfl](https://snowfl.com/)**
 * ⭐ **[Knaben](https://knaben.eu/)**
-* ⭐ **[SolidTorrents](https://solidtorrents.to/)**, [2](https://solidtorrents.eu/)
 * ⭐ **[Torrentz2](https://torrentz2.nz/)**
-* [Bitsearch](https://bitsearch.to/)
 * [Torrent Finder](https://torrent-finder.com/)
 * [TorrentDownload](https://www.torrentdownload.info/)
 * [TorrentQuest](https://torrentquest.com/)


### PR DESCRIPTION
## Description
Removed solidtorrents.to from audiopiracyguide and torrentpiracyguide, and bitsearch.to from torrentpiracyguide.

## Context
Resolves #2347 

## Types of changes
<!--- What types of changes does your Pull Request introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [ ] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [ ] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [ ] My code follows the code style of this project.
