### PR TITLE
added open web ui to Self-Hosting AI tools

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -84,6 +84,7 @@
 * [GPT4All](https://www.nomic.ai/gpt4all) - Self-Hosted / [GitHub](https://github.com/nomic-ai/gpt4all) / [Discord](https://discord.com/invite/mGZE39AS3e)
 * [LlamaFile](https://github.com/Mozilla-Ocho/llamafile) - Run LLM with Single Files
 * [Generative AI for Beginners](https://microsoft.github.io/generative-ai-for-beginners/) - Generative AI Guides
+* [OpenWebUI](https://openwebui.com/) - Self-Hosted, ChatGPT like LLM frontend / [GitHub](https://github.com/open-webui/open-webui)
 
 ***
 


### PR DESCRIPTION
## Description
Added a LLM frontend (OpenWebUI) to the Self-Hosted section of the AI page

## Context
I was looking through the AI site and noticed that a forntend for llms is missing. OpenWebUI differs form the projects mentioned, by being a WebUI only, without an runtime for the model.

## Types of changes
- [ ] Bad / Deleted sites removal
- [ ] Grammar / Markdown fixes 
- [x] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply to this Pull Request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [x] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [x] My code follows the code style of this project.
