### PR TITLE
Braflix URL Fix

### DIFF
--- a/docs/videopiracyguide.md
+++ b/docs/videopiracyguide.md
@@ -9,7 +9,7 @@
 ## ▷ Multi Server
 
 * ⭐ **[movie-web](https://erynith.github.io/movie-web-instances/)**, [2](https://docs.undi.rest/instances) - Movies / TV / Anime / 4K / 1080p / Ad-Free / [Add Sources](https://pastebin.com/w8Brq2UA) / [Docs](https://docs.undi.rest/)
-* ⭐ **[Braflix](https://www.braflix.ru/)** - Movies / TV / Anime / 4K / 1080p / [Discord](https://discord.com/invite/dexBcDVdEk)
+* ⭐ **[Braflix](https://www.braflix.st/)** - Movies / TV / Anime / 4K / 1080p / [Discord](https://discord.com/invite/dexBcDVdEk)
 * ⭐ **[Binged](https://binged.to/)** - Movies / TV / Anime / 1080p / [Discord](https://discord.gg/f2SvhcKCKS)
 * ⭐ **[watch.lonelil](https://watch.lonelil.ru/)** - Movies / TV / Anime / 4K / 1080p / [Discord](https://discord.com/invite/BKts6Jb5sA) / [Telegram](https://t.me/watchlonelil)
 * ⭐ **[HydraHD](https://hydrahd.cc/)** - Movies / TV / Anime / 1080p


### PR DESCRIPTION
## Description
Braflix recently changed its URL from braflix.ru to braflix.st, so I changed it here.

## Context
When the old domain redirect is disabled, people won't be able to access Braflix through the current URL.

## Types of changes
- [ ] Bad / Deleted sites removal
- [X] Grammar / Markdown fixes 
- [ ] Content addition (sites, projects, tools, etc.)
- [ ] New Wiki section

## Checklist:
- [x] I have read the [contribution guide](https://fmhy.net/other/contributing).
- [X] I have made sure to [search](https://api.fmhy.net/single-page) before making any changes. 
- [X] My code follows the code style of this project.
